### PR TITLE
Listen kinesis document queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+# node-lambda ignores
+.env
+deploy.env
+event.json
+context.json

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ We use Elasticsearch index aliases to enable zero-downtime rebuilds. This means 
 
 ```
 node jobs/index-admin list
-Indexes: 
+Indexes:
   ...
   resources-2017-01-09.2 (20684 records)
   resources-2017-01-09 > "resources" (474603 records)
@@ -54,3 +54,34 @@ So, for example, to create an alias called 'resources' pointing to index 'resour
 ```node jobs/index-admin activate --index resources-2017-01-09```
 
 The code assumes from the timestamped index name that the desired alias is "resources" and will unassign the "resources" alias if it already exists.
+
+### Local Lambda development
+
+Install node-lambda if necessary and setup
+
+```
+npm install -g node-lambda
+node-lambda setup
+```
+
+Copy `event.document.sample.json` data into `event.json`. It's encoded with avro schema in base64, but will eventually resolve to something like this:
+
+```
+{"uri":"doc1","type":"test"}
+{"uri":"doc2","type":"test"}
+{"uri":"doc3","type":"test"}
+```
+
+Run lambda locally using data in `event.json`
+
+```
+node-lambda run --handler document-stream-listener.handler
+```
+
+Will execute the equivalent of:
+
+```
+./jobs/index-resources --uri doc1
+./jobs/index-resources --uri doc2
+./jobs/index-resources --uri doc3
+```

--- a/README.md
+++ b/README.md
@@ -85,3 +85,11 @@ Will execute the equivalent of:
 ./jobs/index-resources --uri doc2
 ./jobs/index-resources --uri doc3
 ```
+
+Deploy to an existing Lambda like:
+
+```
+node-lambda deploy --functionName indexDocumentQueue --environment production
+```
+
+Will deploy to a Lambda called indexDocumentQueue-production. Add a Kinesis stream trigger to execute function if not already added.

--- a/document-avro-schema.js
+++ b/document-avro-schema.js
@@ -1,0 +1,9 @@
+// defines avro schema
+module.exports = {
+  name: 'Document',
+  type: 'record',
+  fields: [
+    {name: 'uri', type: 'string'},
+    {name: 'type', type: 'string'}
+  ]
+};

--- a/document-stream-listener.js
+++ b/document-stream-listener.js
@@ -1,0 +1,76 @@
+/*
+  This is a lambda that listens to the discovery-queue-manager (https://github.com/NYPL-discovery/discovery-queue-manager)
+  via a Kinesis stream that contains document URIs that should be indexed/re-indexed
+  then runs the index job with the document URI
+*/
+
+console.log('Loading Document Stream Listener');
+
+const _ = require('highland');
+const avro = require('avsc');
+const childProcess = require('child_process');
+const schema = require('./document-avro-schema.js');
+
+// kinesis stream handler
+exports.kinesisHandler = function(records, context) {
+  console.log('Processing ' + records.length + ' records');
+
+  // initialize avro schema
+  const avroType = avro.parse(schema);
+
+  // process kinesis records
+  var data = records
+    .map(parseData);
+
+  // index each document
+  _(data)
+    .each(indexDocument);
+
+  // executes a index resource job with URI
+  function indexDocument(doc) {
+    var args = ['--uri', `${doc.uri}`];
+    runScript(`./jobs/index-resources`, args, function (err) {
+      if (err) throw err;
+    });
+  }
+
+  // map to records objects as needed
+  function parseData(payload) {
+    // decode base64
+    var buf = new Buffer(payload.kinesis.data, 'base64');
+    // decode avro
+    var record = avroType.fromBuffer(buf);
+    return record;
+  }
+
+  function runScript(scriptPath, args, callback) {
+    // keep track of whether callback has been invoked to prevent multiple invocations
+    var invoked = false;
+    var process = childProcess.fork(scriptPath, args);
+
+    // listen for errors as they may prevent the exit event from firing
+    process.on('error', function (err) {
+      if (invoked) return;
+      invoked = true;
+      callback(err);
+    });
+
+    // execute the callback once the process has finished running
+    process.on('exit', function (code) {
+      if (invoked) return;
+      invoked = true;
+      var err = code === 0 ? null : new Error('exit code ' + code);
+      callback(err);
+    });
+  }
+
+  context.done();
+};
+
+// main function
+exports.handler = function(event, context) {
+  var record = event.Records[0];
+  if (record.kinesis) {
+    exports.kinesisHandler(event.Records, context);
+  }
+};

--- a/event.document.sample.json
+++ b/event.document.sample.json
@@ -1,0 +1,50 @@
+{
+  "Records": [
+    {
+      "kinesis": {
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "s1",
+        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001",
+        "data": "CGRvYzEIdGVzdA==",
+        "approximateArrivalTimestamp": 1428537600
+      },
+      "eventSource": "aws:kinesis",
+      "eventVersion": "1.0",
+      "eventID": "shardId-000000000000:00000000000000000000000000000000000000000000000000000001",
+      "eventName": "aws:kinesis:record",
+      "invokeIdentityArn": "arn:aws:iam::EXAMPLE",
+      "awsRegion": "us-east-1",
+      "eventSourceARN": "arn:aws:kinesis:EXAMPLE"
+    },{
+      "kinesis": {
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "s1",
+        "sequenceNumber": "00000000000000000000000000000000000000000000000000000003",
+        "data": "CGRvYzIIdGVzdA==",
+        "approximateArrivalTimestamp": 1428537600
+      },
+      "eventSource": "aws:kinesis",
+      "eventVersion": "1.0",
+      "eventID": "shardId-000000000000:00000000000000000000000000000000000000000000000000000003",
+      "eventName": "aws:kinesis:record",
+      "invokeIdentityArn": "arn:aws:iam::EXAMPLE",
+      "awsRegion": "us-east-1",
+      "eventSourceARN": "arn:aws:kinesis:EXAMPLE"
+    },{
+      "kinesis": {
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "s1",
+        "sequenceNumber": "00000000000000000000000000000000000000000000000000000004",
+        "data": "CGRvYzMIdGVzdA==",
+        "approximateArrivalTimestamp": 1428537600
+      },
+      "eventSource": "aws:kinesis",
+      "eventVersion": "1.0",
+      "eventID": "shardId-000000000000:00000000000000000000000000000000000000000000000000000004",
+      "eventName": "aws:kinesis:record",
+      "invokeIdentityArn": "arn:aws:iam::EXAMPLE",
+      "awsRegion": "us-east-1",
+      "eventSourceARN": "arn:aws:kinesis:EXAMPLE"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "author": "NYPL Discovery",
   "dependencies": {
+    "avsc": "^4.1.11",
     "JSONStream": "^1.2.1",
     "blessed": "^0.1.81",
     "blessed-contrib": "^3.5.5",


### PR DESCRIPTION
This PR adds a Lambda function/handler (document-stream-listener.js) that listens to a stream of document URIs, then runs on each document URI

```
./jobs/index-resources --uri <document uri>
```

[Updated README](https://github.com/NYPL-discovery/discovery-api-indexer/tree/listen-kinesis-document-queue#local-lambda-development) to test this lambda locally