### PR TITLE
Make outgoing stream name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Ensure `deploy.env` has the following:
 DISCOVERY_STORE_CONNECTION_URI=[encrypted rds connection string]
 ELASTICSEARCH_CONNECTION_URI=[encrypted es connection string, which in plaintext could be "localhost:9200"]
 ELASTIC_RESOURCES_INDEX_NAME=[name of resources index]
-NYPL_API_SCHEMA_URL=https://platform.nypl.org/api/v0.1/current-schemas/
-NYPL_API_BASE_URL=https://platform.nypl.org/api/v0.1/
+NYPL_API_SCHEMA_URL=[plaintext schema base url ending in '/current-schemas/']
+NYPL_API_BASE_URL=[plaintext data api base url ending in, for example, '/v0.1/']
 OUTGOING_STREAM_NAME=[name of kinesis stream to write to, e.g. "IndexDocumentProcessed"]
 OUTGOING_SCHEMA_NAME=[name of avro schema to encode outgoing messages against, e.g. "IndexDocumentProcessed-development"]
 LOGLEVEL=info

--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@ node-lambda setup
 Ensure `deploy.env` has the following:
 ```
 DISCOVERY_STORE_CONNECTION_URI=[encrypted rds connection string]
-ELASTICSEARCH_CONNECTION_URI=[encrypted es connection string]
-NYPL_API_SCHEMA_URI=[*not* encrypted nypl data api base url]
-LOGLEVEL=info
+ELASTICSEARCH_CONNECTION_URI=[encrypted es connection string, which in plaintext could be "localhost:9200"]
 ELASTIC_RESOURCES_INDEX_NAME=[name of resources index]
+NYPL_API_SCHEMA_URL=https://platform.nypl.org/api/v0.1/current-schemas/
+NYPL_API_BASE_URL=https://platform.nypl.org/api/v0.1/
+OUTGOING_STREAM_NAME=[name of kinesis stream to write to, e.g. "IndexDocumentProcessed"]
+OUTGOING_SCHEMA_NAME=[name of avro schema to encode outgoing messages against, e.g. "IndexDocumentProcessed-development"]
+LOGLEVEL=info
 ```
 
 Similarly, `.env` should minimally have:

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ ELASTICSEARCH_CONNECTION_URI=[encrypted es connection string, which in plaintext
 ELASTIC_RESOURCES_INDEX_NAME=[name of resources index]
 NYPL_API_SCHEMA_URL=[plaintext schema base url ending in '/current-schemas/']
 NYPL_API_BASE_URL=[plaintext data api base url ending in, for example, '/v0.1/']
-OUTGOING_STREAM_NAME=[name of kinesis stream to write to, e.g. "IndexDocumentProcessed"]
-OUTGOING_SCHEMA_NAME=[name of avro schema to encode outgoing messages against, e.g. "IndexDocumentProcessed-development"]
+OUTGOING_STREAM_NAME=[name of kinesis stream to write to, e.g. "IndexDocumentProcessed-development"]
+OUTGOING_SCHEMA_NAME=[name of avro schema to encode outgoing messages against, e.g. "IndexDocumentProcessed"]
 LOGLEVEL=info
 ```
 

--- a/lib/env-config-helper.js
+++ b/lib/env-config-helper.js
@@ -32,7 +32,7 @@ function getConfig () {
 
 function init (clients) {
   // Ensure necessary env variables loaded
-  dotenv.config({ path: './deploy.production.env' })
+  dotenv.config({ path: './deploy.env' })
   dotenv.config({ path: './.env' })
 
   // What index are we writing to?

--- a/lib/env-config-helper.js
+++ b/lib/env-config-helper.js
@@ -32,7 +32,7 @@ function getConfig () {
 
 function init (clients) {
   // Ensure necessary env variables loaded
-  dotenv.config({ path: './deploy.env' })
+  dotenv.config({ path: './deploy.production.env' })
   dotenv.config({ path: './.env' })
 
   // What index are we writing to?

--- a/lib/resource-indexer.js
+++ b/lib/resource-indexer.js
@@ -7,14 +7,14 @@ const NyplStreamsClient = require('@nypl/nypl-streams-client')
 const index = require('./index')
 const ResourceSerializer = require('./es-serializer').ResourceSerializer
 
-const OUTGOING_SCHEMA_TYPE = process.env['OUTGOING_SCHEMA_TYPE'] || 'IndexDocumentProcessed'
+const OUTGOING_SCHEMA_NAME = process.env['OUTGOING_SCHEMA_NAME'] || 'IndexDocumentProcessed'
+const OUTGOING_STREAM_NAME = process.env['OUTGOING_STREAM_NAME'] || 'IndexDocumentProcessed'
 
 function writeResourcesToIndex (resources) {
   log.debug('Saving batch of ' + resources.length + 'resources', resources)
   return index.resources.save(process.env['ELASTIC_RESOURCES_INDEX_NAME'], resources)
     .then((result) => {
-      if (result && result.errors) return Promise.reject('Elastic reports errors: ' + result.errors + ': ' + JSON.stringify(result.errors, null, 2))
-      else return
+      if (result && result.errors) return Promise.reject(new Error('Elastic reports errors: ' + result.errors + ': ' + JSON.stringify(result.errors, null, 2)))
     })
     .then(() => resources)
 }
@@ -36,11 +36,11 @@ function notifyIndexDocumentProcessed (resources) {
 
   // Pass records to streams client:
   return (new NyplStreamsClient({ nyplDataApiClientBase: process.env['NYPL_API_BASE_URL'], logLevel: 'error' }))
-    .write(OUTGOING_SCHEMA_TYPE, indexDocumentProcessedRecords)
+    .write(OUTGOING_STREAM_NAME, indexDocumentProcessedRecords, { avroSchemaName: OUTGOING_SCHEMA_NAME })
     .then((res) => {
-      log.info(`Wrote ${res.Records.length} records to ${OUTGOING_SCHEMA_TYPE}`)
+      log.info(`Wrote ${res.Records.length} records to ${OUTGOING_STREAM_NAME}`)
     }).catch((e) => {
-      log.error(`Error writing to to ${OUTGOING_SCHEMA_TYPE}`, e)
+      log.error(`Error writing to to ${OUTGOING_STREAM_NAME}`, e)
     })
 }
 

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
   "devDependencies": {
     "dotenv": "^4.0.0",
     "minimist": "^1.2.0",
+    "standard": "^6.0.3",
     "mocha": "^3.2.0"
   },
   "scripts": {
-    "test": "standard && mocha test"
+    "test": "./node_modules/.bin/standard && mocha test"
   },
   "description": "",
   "license": "MIT",


### PR DESCRIPTION
This PR:

 - makes the "outgoing stream" (the stream written to after a doc is indexed) configurable via a new env var "OUTGOING_STREAM_NAME"
 - clarifies outgoing *schema* name configuration & documentation
 - clarifies NYPL API base url documentation
 - adds `standard` as dev dependency, locked at older version known to validate