### PR TITLE
Fix inconsistent e-resource indexing

### DIFF
--- a/lib/es-serializer.js
+++ b/lib/es-serializer.js
@@ -185,7 +185,7 @@ class ResourceSerializer extends EsSerializer {
     // Add finding aids and that sorta thing:
     bibFieldMapper.getMapping('Supplementary content', (spec) => {
       this.object.each(spec.pred, (triple) => {
-        this.addStatement(spec.jsonLdKey, triple.object_literal, triple.object_label, { addPackedField: false })
+        this.addStatement(spec.jsonLdKey, { url: triple.object_literal, label: triple.object_label })
       })
     })
 
@@ -216,11 +216,15 @@ class ResourceSerializer extends EsSerializer {
           // Add default shelfMark if missing:
           .map((item) => {
             // Only set default shelfMark if not electronic
-            if (!item.shelfMark && !item.electronicLocation) item.shelfMark = defaultShelfMark
+            if (!item.shelfMark && !item.electronicLocator) item.shelfMark = defaultShelfMark
             return item
           })
           // Sort items by callnumber, id
           .sort((i1, i2) => {
+            // If no shelfMark (i.e. electronic resource), list last
+            if (!i1.shelfMark || i1.shelfMark.length === 0) return 1
+            if (!i2.shelfMark || i2.shelfMark.length === 0) return -1
+
             // If we have callnumbers, order by those:
             if (i1['shelfMark'] && i2['shelfMark']) {
               // zero-pad trailing integers (box / tube /vol number)
@@ -306,7 +310,7 @@ class ResourceItemSerializer extends EsSerializer {
     // Note this comes from bib mapping because that's where it's extracted from:
     bibFieldMapper.getMapping('Electronic location', (spec) => {
       this.object.each(spec.pred, (triple) => {
-        this.addStatement(spec.jsonLdKey, triple.object_literal, triple.object_label, { addPackedField: false })
+        this.addStatement(spec.jsonLdKey, { url: triple.object_literal, label: triple.object_label })
       })
       // TODO This is a temporary hack to fix fact most resources encoded using this incorrect pred:
       // Remove this once statements remapped to 'bf:electronicLocator'

--- a/lib/index.js
+++ b/lib/index.js
@@ -123,6 +123,12 @@ var prepareResourcesIndex = (indexName, deleteIfExists) => {
         catalogItemType_packed: mappingTemplates.packed,
         deliveryLocation: mappingTemplates.entity,
         deliveryLocation_packed: mappingTemplates.packed,
+        electronicLocator: {
+          properties: {
+            url: mappingTemplates.exactString,
+            label: { type: 'keyword', index: false }
+          }
+        },
         holdingLocation: mappingTemplates.entity,
         holdingLocation_packed: mappingTemplates.packed,
         // idBarcode: mappingTemplates.exactString,

--- a/test/bib-serializations-test.js
+++ b/test/bib-serializations-test.js
@@ -221,7 +221,7 @@ describe('Bib Serializations', function () {
     it('should have Supplementary content', function () {
       return Bib.byId('b18932917').then((bib) => {
         return ResourceSerializer.serialize(bib).then((serialized) => {
-          assert.equal(serialized.supplementaryContent[0].id, 'http://archives.nypl.org/uploads/collection/pdf_finding_aid/PSF.pdf')
+          assert.equal(serialized.supplementaryContent[0].url, 'http://archives.nypl.org/uploads/collection/pdf_finding_aid/PSF.pdf')
           assert.equal(serialized.supplementaryContent[0].label, 'FindingAid')
         })
       })


### PR DESCRIPTION
This PR:
 - Makes the indexing of electronic resources consistent between `bib.supplementaryContent` and `item.electronicLocator`
 - Ensure electronic items are sorted last (previously sorted by bib shelfmark)
 - Fix bug where electronic items acquired bib shelfMark
 - Adds formal mapping for item.electronicLocator (previously undefined, which was harmless, but would make filtering difficult if we ever needed to do that)