### PR TITLE
New catalogItemType suppression rule

### DIFF
--- a/lib/models/item.js
+++ b/lib/models/item.js
@@ -1,13 +1,16 @@
-'use strict'
-
+const catalogItemTypeMapping = require('@nypl/nypl-core-objects')('by-catalog-item-type')
 const Base = require('./base')
 const db = require('../db')
 
 class Item extends Base {
   isResearch () {
-    // Research items have catalogItemType between 1-100
-    return /^[pc]/.test(this.uri) ||
-      /catalogItemType:(\d{1,2}|100)$/.test(this.objectId('nypl:catalogItemType'))
+    // Check catalogItemTypes json-ld vocab to see if itype's collectionTypes includes 'Research':
+    let itype = this.objectId('nypl:catalogItemType')
+    let itypeIsResearch = itype &&
+      catalogItemTypeMapping[itype] &&
+      catalogItemTypeMapping[itype].collectionType.indexOf('Research') >= 0
+
+    return /^[pc]/.test(this.uri) || itypeIsResearch
   }
 }
 

--- a/lib/models/item.js
+++ b/lib/models/item.js
@@ -3,6 +3,20 @@ const Base = require('./base')
 const db = require('../db')
 
 class Item extends Base {
+  /*
+   * Returns true if this item is considered a 'Research' item, which will be
+   * true if:
+   *
+   *   * It's a partner record OR
+   *   * Its itype's collectionType includes 'Research'
+   *
+   * The determination made here doesn't directly control whether or not an
+   * item is indexed. An item will be indexed if it is not `suppressed`,
+   * which is established upstream in the `pcdm-store-updater`. The check
+   * performed here exists solely to determine whether the parent Bib is
+   * 'Research', which will be true if it has at least one Item that is
+   * considered 'Research'
+   */
   isResearch () {
     // Check catalogItemTypes json-ld vocab to see if itype's collectionTypes includes 'Research':
     let itype = this.objectId('nypl:catalogItemType')

--- a/lib/models/item.js
+++ b/lib/models/item.js
@@ -6,6 +6,8 @@ class Item extends Base {
   isResearch () {
     // Check catalogItemTypes json-ld vocab to see if itype's collectionTypes includes 'Research':
     let itype = this.objectId('nypl:catalogItemType')
+    // Strip namespace from id:
+    if (itype) itype = itype.split(':').pop()
     let itypeIsResearch = itype &&
       catalogItemTypeMapping[itype] &&
       catalogItemTypeMapping[itype].collectionType.indexOf('Research') >= 0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "author": "NYPL Discovery",
   "dependencies": {
+    "@nypl/nypl-core-objects": "^1.2.0",
     "@nypl/nypl-streams-client": "^0.1.2",
     "JSONStream": "^1.2.1",
     "avsc": "^5.0.0",

--- a/test/bib-serializations-test.js
+++ b/test/bib-serializations-test.js
@@ -339,5 +339,18 @@ describe('Bib Serializations', function () {
         })
       })
     })
+
+    it('should include itypes 132', function () {
+      // Note: Other itypes > 100 that should be indexed include 133, 134, 135, & 142
+      return Bib.byId('b17655587').then((bib) => {
+        return ResourceSerializer.serialize(bib).then((serialized) => {
+          // This bib has 6 items at writing. Four are suppressed by icode2 rules.
+          // Two have itype 132 and should not be suppressed
+          // Confirm the bib has them:
+          let itemsWithHighItype = serialized.items.filter((item) => item.catalogItemType[0].id === 'catalogItemType:132')
+          assert(itemsWithHighItype.length > 0)
+        })
+      })
+    })
   })
 })

--- a/test/item-model-test.js
+++ b/test/item-model-test.js
@@ -1,0 +1,54 @@
+/* global describe it before */
+
+const assert = require('assert')
+const dotenv = require('dotenv')
+const log = require('loglevel')
+
+const db = require('../lib/db')
+const Bib = require('../lib/models/bib')
+const kmsHelper = require('../lib/kms-helper')
+
+function dbConnect () {
+  if (db.connected()) return Promise.resolve()
+  else {
+    return kmsHelper.decryptDbCreds()
+      .then((uri) => db.setConnection(uri))
+  }
+}
+
+function init () {
+  // TODO this will look very different after new config/deploy PR merged.
+  // Ensure necessary env variables loaded
+  dotenv.config({ path: './deploy.env' })
+  dotenv.config({ path: './.env' })
+
+  log.setLevel(process.env.LOGLEVEL || 'info')
+
+  return Promise.all([ dbConnect() ])
+}
+
+describe('Item Model', function () {
+  this.timeout(5000)
+
+  before(init)
+
+  it('should include itypes 132', function () {
+    return Bib.byId('b17655587').then((bib) => {
+      // This bib has 6 items at writing. Four are suppressed by icode2 rules.
+      // Two have itype 132 and should not be suppressed. Those two should be
+      // considered 'Research' because itype 132 has collectionType 'Research' in
+      // https://github.com/NYPL/nypl-core/blob/master/vocabularies/json-ld/catalogItemTypes.json
+
+      // Grab the two items with itype 132:
+      let itemsWithHighItype = bib._items.filter((item) => item.objectId('nypl:catalogItemType') === 'catalogItemType:132')
+
+      // Confirm there are two:
+      assert.equal(itemsWithHighItype.length, 2)
+
+      // Confirm each of them self reports as research:
+      itemsWithHighItype.forEach((item) => {
+        assert(item.isResearch())
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR handles the Indexer side of the catalogItemTypes biz requirements change that allows certain catalogItemTypes > 100 to be flagged as 'Research'. Previously we considered an `itype` as implying 'Research' if the itype was <= 100. The new rule adds new `itype`s > 100 to this classification. Rather than continue hard-coding this increasingly complex check, this PR brings in `nypl-core-objects` to use a new `catalogItemType.collectionType` property to determine the 'Research'-ness of a given `itype`.

Note that the 'Research'-ness of an item does not directly determine whether or not it will be indexed. That is controlled by the `suppressed` flag which is set upstream by the `pcdm-store-updater` based on a number of checks that include checking whether or not it's a 'Research' item. The `Item.isResearch` method modified in this PR is used solely to determine whether the parent Bib is 'Research' (i.e. a bib with at least one 'Research' item will itself be 'Research'). This PR includes a test to confirm that the Item model calculates `isResearch` correctly for a known item with one of the new `itype`s now considered as 'Research' 