### PR TITLE
Standardize how we deploy to node-lambda

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+AWS_REGION=us-east-1
+AWS_FUNCTION_NAME=DiscoveryIndexPoster
+AWS_HANDLER=document-stream-listener.handler
+AWS_MEMORY_SIZE=832
+AWS_TIMEOUT=300
+AWS_RUNTIME=nodejs6.10
+EXCLUDE_GLOBS="event.json"
+PACKAGE_DIRECTORY=build

--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,8 @@ node_modules
 .node_repl_history
 
 # node-lambda ignores
-.env
-deploy.env
+config/production.env
+config/qa.env
 event.json
 context.json
 

--- a/README.md
+++ b/README.md
@@ -12,48 +12,7 @@ npm i
 
 This app is deployed as lambda `discoveryIndexerPoster`. It can also be invoked in "bulk" mode.
 
-### Lambda Development & Deploy
-
-To develop or run the lambda locally, first set up your node-lambda env:
-
-```
-npm install -g node-lambda
-node-lambda setup
-```
-
-Ensure `deploy.env` has the following:
-```
-DISCOVERY_STORE_CONNECTION_URI=[encrypted rds connection string]
-ELASTICSEARCH_CONNECTION_URI=[encrypted es connection string, which in plaintext could be "localhost:9200"]
-ELASTIC_RESOURCES_INDEX_NAME=[name of resources index]
-NYPL_API_SCHEMA_URL=[plaintext schema base url ending in '/current-schemas/']
-NYPL_API_BASE_URL=[plaintext data api base url ending in, for example, '/v0.1/']
-OUTGOING_STREAM_NAME=[name of kinesis stream to write to, e.g. "IndexDocumentProcessed-development"]
-OUTGOING_SCHEMA_NAME=[name of avro schema to encode outgoing messages against, e.g. "IndexDocumentProcessed"]
-LOGLEVEL=info
-```
-
-Similarly, `.env` should minimally have:
-```
-AWS_ACCESS_KEY_ID=...
-AWS_SECRET_ACCESS_KEY=...
-AWS_PROFILE=
-AWS_SESSION_TOKEN=
-AWS_ROLE_ARN=arn:aws:iam::224280085904:role/lambda_basic_execution
-AWS_REGION=us-east-1
-AWS_FUNCTION_NAME=discoveryIndexPoster
-AWS_HANDLER=document-stream-listener.handler
-AWS_MEMORY_SIZE=512
-AWS_TIMEOUT=30
-AWS_DESCRIPTION=
-AWS_RUNTIME=nodejs6.10
-AWS_VPC_SUBNETS=subnet-f4fe56af
-AWS_VPC_SECURITY_GROUPS=sg-1d544067
-EXCLUDE_GLOBS="event.json"
-PACKAGE_DIRECTORY=build
-AWS_ROLE_ARN=...
-AWS_REGION=...
-```
+### Test Events
 
 Edit `event.unencoded.json` with your desired test ids. Then commit your changes to `event.json` using the `kinesify-data` utility as follows:
 
@@ -64,20 +23,21 @@ node kinesify-data event.unencoded.json event.json https://api.nypltech.org/api/
 To run the app locally against `event.json`
 
 ```
-node-lambda run -f deploy.env
+node-lambda run -f config/qa.env
 ```
 
-To *deploy* to an existing Lambda like:
+### Deploying
 
-```
-node-lambda deploy -f deploy.env
-```
-
-This will deploy to a Lambda called "discoveryIndexPoster". Add a Kinesis stream trigger to execute function if not already added.
+1. Copy sample environment-specific by running:  `cp ./config/sample.env ./config/production.env && cp ./config/sample.env ./config/qa.env`
+1. Fill in missing secrets in both environment files (talk to a coworker)
+1. `npm run deploy-[qa|production]`
 
 ### Bulk Building Resources Index
 
-The non-lambda invocation method is provided for bulk processing. It's generally faster to use the bulk method to load millions of documents.
+**CAVEAT: The scripts in `./jobs` will need some local editing until we resolve
+[issue 17](https://github.com/NYPL-discovery/discovery-api-indexer/issues/17).**
+
+The non-lambda invocation method is provided for bulk processing. It's generally faster to use the bulk method to load millions of documents.S
 
 To populate the index identified in `deploy.env` (described above):
 

--- a/config/event-sources-production.json
+++ b/config/event-sources-production.json
@@ -1,0 +1,10 @@
+{
+  "EventSourceMappings": [
+    {
+      "EventSourceArn": "arn:aws:kinesis:us-east-1:946183545209:stream/IndexDocument-production",
+      "StartingPosition": "LATEST",
+      "BatchSize": 100,
+      "Enabled": true
+    }
+  ]
+}

--- a/config/event-sources-qa.json
+++ b/config/event-sources-qa.json
@@ -1,0 +1,10 @@
+{
+  "EventSourceMappings": [
+    {
+      "EventSourceArn": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument",
+      "StartingPosition": "LATEST",
+      "BatchSize": 100,
+      "Enabled": true
+    }
+  ]
+}

--- a/config/sample.env
+++ b/config/sample.env
@@ -1,0 +1,8 @@
+DISCOVERY_STORE_CONNECTION_URI=[KMS encrypted database connection string]
+ELASTICSEARCH_CONNECTION_URI=[KMS encrypted ElasticSearch connection string]
+NYPL_API_SCHEMA_URL=https://[API-GATEWAY-FQDN]/api/v0.1/current-schemas/
+NYPL_API_BASE_URL=https://[API-GATEWAY-FQDN]/api/v0.1/
+LOGLEVEL=[info (prod)|debug (qa)]
+ELASTIC_RESOURCES_INDEX_NAME=[Name of the Elasticsearch index]
+OUTGOING_SCHEMA_NAME=IndexDocumentProcessed
+OUTGOING_STREAM_NAME=[Name of Kinesis stream to publish to]

--- a/package.json
+++ b/package.json
@@ -22,12 +22,15 @@
     "dotenv": "^4.0.0",
     "minimist": "^1.2.0",
     "standard": "^6.0.3",
-    "mocha": "^3.2.0"
+    "mocha": "^3.2.0",
+    "node-lambda": "^0.11.3"
   },
   "scripts": {
-    "test": "./node_modules/.bin/standard && mocha test"
+    "test": "./node_modules/.bin/standard && mocha test",
+    "deploy-qa": "./node_modules/.bin/node-lambda deploy -e qa -f ./config/qa.env -b subnet-f4fe56af -g sg-1d544067 --role arn:aws:iam::224280085904:role/lambda_basic_execution --profile nypl-sandbox -S config/event-sources-qa.json",
+    "deploy-production": "./node_modules/.bin/node-lambda deploy -e production -f ./config/production.env -b subnet-59bcdd03,subnet-5deecd15 -g sg-116eeb60 --role arn:aws:iam::946183545209:role/lambda-full-access --profile nypl-digital-dev -S config/event-sources-production.json"
   },
-  "description": "",
+  "description": "Listens to IndexDocument[-env], pulls data from discovery-store, writes it to ES, notifies IndexDocumentProcessed[-env]",
   "license": "MIT",
   "name": "discovery-api-indexer",
   "preferGlobal": false,

--- a/test/bib-serializations-test.js
+++ b/test/bib-serializations-test.js
@@ -18,9 +18,19 @@ function dbConnect () {
 }
 
 function init () {
-  // Ensure necessary env variables loaded
-  dotenv.config({ path: './deploy.env' })
-  dotenv.config({ path: './.env' })
+  // Load QA connection strings
+  dotenv.config({ path: 'config/qa.env' })
+
+  const aws = require('aws-sdk')
+
+  // Set aws creds:
+  aws.config.credentials = new aws.SharedIniFileCredentials({
+    profile: 'nypl-sandbox'
+  })
+
+  // Set aws region:
+  let awsSecurity = { region: 'us-east-1' }
+  aws.config.update(awsSecurity)
 
   log.setLevel(process.env.LOGLEVEL || 'info')
 

--- a/test/bib-serializations-test.js
+++ b/test/bib-serializations-test.js
@@ -221,7 +221,7 @@ describe('Bib Serializations', function () {
     it('should have Supplementary content', function () {
       return Bib.byId('b18932917').then((bib) => {
         return ResourceSerializer.serialize(bib).then((serialized) => {
-          assert.equal(serialized.supplementaryContent[0].id, 'http://archives.nypl.org/uploads/collection/pdf_finding_aid/PSF.pdf')
+          assert.equal(serialized.supplementaryContent[0].url, 'http://archives.nypl.org/uploads/collection/pdf_finding_aid/PSF.pdf')
           assert.equal(serialized.supplementaryContent[0].label, 'FindingAid')
         })
       })


### PR DESCRIPTION
This allows us to keep .env in source control while hiding:

* IAM credentials in ~/.aws dir
* Application runtime vars in ./config/[envname].env

For more information: https://github.com/NYPL/engineering-general/blob/master/standards/node-lambda.md