### PR TITLE
Change type check to use rdfs:type instead of rdf:

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -67,7 +67,7 @@ var resources = new (class {
     }
 
     var whereClauses = [
-      "B.predicate='rdf:type'",
+      "B.predicate='rdfs:type'",
       "B.object_id IN ('nypl:Item', 'nypl:Collection')"
     ]
     // Match one subject:


### PR DESCRIPTION
This is a long overdue fix to the Indexer to ensure it's checking the
new official predicate identifying the type of records. Previously it
was rdf:type, but as of Winter 2016, new DiscoveryStorePoster
serializations have started using rdfs:type. This change in the Indexer
is necessary to ensure Item & Collection type records are identified.