### PR TITLE
Change item.isResearch to eval true if electronic

### DIFF
--- a/lib/models/item.js
+++ b/lib/models/item.js
@@ -8,6 +8,7 @@ class Item extends Base {
    * true if:
    *
    *   * It's a partner record OR
+   *   * It's a generated electronic record:
    *   * Its itype's collectionType includes 'Research'
    *
    * The determination made here doesn't directly control whether or not an
@@ -18,15 +19,21 @@ class Item extends Base {
    * considered 'Research'
    */
   isResearch () {
+    // We know it's a partner item if its id starts in p[ul] or c[ul]:
+    const isPartnerItem = /^[pc]/.test(this.uri)
+
+    // We know it's a generated electronic item if it has a bf:electronicLocator predicate:
+    const isElectronicItem = this.literal('bf:electronicLocator')
+
     // Check catalogItemTypes json-ld vocab to see if itype's collectionTypes includes 'Research':
     let itype = this.objectId('nypl:catalogItemType')
     // Strip namespace from id:
     if (itype) itype = itype.split(':').pop()
-    let itypeIsResearch = itype &&
+    const itypeIsResearch = itype &&
       catalogItemTypeMapping[itype] &&
       catalogItemTypeMapping[itype].collectionType.indexOf('Research') >= 0
 
-    return /^[pc]/.test(this.uri) || itypeIsResearch
+    return isPartnerItem || isElectronicItem || itypeIsResearch
   }
 }
 


### PR DESCRIPTION
The DiscoveryStorePoster sometimes generates electronic items out of bib
marc fields. When that happens and there are no other physical items
attached to the bib, the result is that the bib.isResearch method will
return false because the bib has more than 0 items and none of them are
explicitly "Research" (normally evaluated via location and itype). This
change adds an additional clause to cause item.isResearch to evaluate to
true if the item is an electronic item. The anticipated effect is that
some bibs that currently are evaluating as non-research because they
have a single electronic item will now evaluate as research.

Related: https://jira.nypl.org/browse/SCC-283