### PR TITLE
Add updated mappings for recently added ES props

### DIFF
--- a/docs/index-admin.md
+++ b/docs/index-admin.md
@@ -23,6 +23,28 @@ If the modification strictly *adds* mappings, one can *normally do that by `PUT`
 }
 ```
 
+As another example, to create a un-indexed, 'keyword' typed mapping for `serialPublicationDates`, issue a `PUT` to "https://[fqdn index]/[current index name]/_mapping/resource" with the following raw body:
+```
+{
+  "properties": {
+    "serialPublicationDates": {
+      "index": false,
+      "type": "keyword"
+    }
+  }
+}
+```
+
+ES will respond with the following to indicate success:
+
+```
+{
+  "acknowledged": true
+}
+```
+
+Thereafter you can confirm the mapping was created by doing a `GET` on "https://[fqdn index]/[current index name]/_mapping/resource" to view the whole mapping.
+
 [Elastic documentation of put mapping](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html)
 
  \* One case where *adding* a mapping may fail is if you've already written documents into the index containing the property that you want to add. Elastic may have made a guess about the mapping type, preventing you from overwriting it.

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,23 +22,37 @@ const mappingTemplates = {
       label: { type: 'keyword', index: true }
     }
   },
+  // This type should be used for "packed" fields containing ids & labels
+  // munged together, which will only be matched exactly:
   packed: {
     index: true,
     type: 'keyword',
     eager_global_ordinals: true
   },
+  // This type should be used for text that we don't need analyzed for fuzzy
+  // searching, but we do want to be able to filter on it using exact matching:
   exactString: {
     index: true,
+    type: 'keyword'
+  },
+  // This type should be used for text not worth analyzing for fuzzy-matching
+  // and we don't expect to ever use it in an exact-match query either:
+  exactStringNotIndexed: {
+    index: false,
     type: 'keyword'
   },
   number: {
     index: true,
     type: 'short'
   },
+  // This type should be used for text properties that we want analyzed for
+  // fuzzy searching, and we never expect to build an aggregation across it:
   fulltext: {
     type: 'text',
     index: true
   },
+  // This type should be used for text properties that we want analyzed for
+  // fuzzy searching, but we also want to store a raw copy for aggregations:
   fulltextWithRaw: {
     type: 'text',
     index: true,
@@ -86,7 +100,9 @@ var prepareResourcesIndex = (indexName, deleteIfExists) => {
   deleteIfExists = (typeof deleteIfExists) === 'undefined' ? false : deleteIfExists
   log.debug('Invoking prepareResourcesIndex on ' + indexName)
 
-  var common_properties = {
+  // The following establishes the resource index mapping as it currently
+  // exists in dev & prod.
+  const resourcesProperties = {
     carrierType: mappingTemplates.entity,
     carrierType_packed: mappingTemplates.packed,
     contributorLiteral: mappingTemplates.fulltextWithRaw,
@@ -107,6 +123,17 @@ var prepareResourcesIndex = (indexName, deleteIfExists) => {
     description: mappingTemplates.fulltext,
     dimensions: mappingTemplates.exactString,
     extent: mappingTemplates.exactString,
+    // TODO This should probably have been mapped to mappingTemplates.fulltextWithRaw
+    // which is pretty equivalent:
+    genreForm: {
+      type: 'text',
+      fields: {
+        keyword: {
+          type: 'keyword',
+          ignore_above: 256
+        }
+      }
+    },
     idLcc: mappingTemplates.exactString,
     idLccSort: mappingTemplates.exactString,
     idOwi: mappingTemplates.exactString,
@@ -131,7 +158,6 @@ var prepareResourcesIndex = (indexName, deleteIfExists) => {
         },
         holdingLocation: mappingTemplates.entity,
         holdingLocation_packed: mappingTemplates.packed,
-        // idBarcode: mappingTemplates.exactString,
         identifier: mappingTemplates.exactString,
         location: mappingTemplates.entity,
         owner: mappingTemplates.entity,
@@ -146,20 +172,54 @@ var prepareResourcesIndex = (indexName, deleteIfExists) => {
     materialType_packed: mappingTemplates.packed,
     mediaType: mappingTemplates.entity,
     mediaType_packed: mappingTemplates.packed,
-    note: {'type': 'string', 'index': 'analyzed'},
+    // Note that this is aliased `note`
+    noteV2: {
+      properties: {
+        // TODO This is probably better as mappingTemplates.fulltext
+        // Because we don't need the raw "keyword" field.
+        // But this is the current mapping:
+        label: {
+          type: 'text',
+          fields: {
+            keyword: {
+              type: 'keyword',
+              ignore_above: 256
+            }
+          }
+        },
+        // TODO This is probably better as mappingTemplates.exactString
+        // But this is the current mapping:
+        noteType: {
+          type: 'text',
+          fields: {
+            keyword: {
+              type: 'keyword',
+              ignore_above: 256
+            }
+          }
+        },
+        // TODO This is probably better as mappingTemplates.exactStringNotIndexed
+        // because it only ever contains 'bf:Note'..
+        // But this is the current mapping:
+        type: {
+          type: 'text',
+          fields: {
+            keyword: {
+              type: 'keyword',
+              ignore_above: 256
+            }
+          }
+        }
+      }
+    },
     numAvailable: mappingTemplates.number,
     numItems: mappingTemplates.number,
-    // parentUri: {'type': 'integer', 'index': 'not_analyzed'},
-    // parentUris: {'type': 'integer', 'index': 'not_analyzed'},
-    // parentUris_packed: {'type': 'string', 'index': 'not_analyzed'},
     placeOfPublication: mappingTemplates.exactString,
     publicDomain: mappingTemplates.boolean,
     publisher: mappingTemplates.exactString,
-    // rootParentUri: {'type': 'integer', 'index': 'not_analyzed'},
-    // rootParentUri_packed: {'type': 'string', 'index': 'not_analyzed'},
+    publicationStatement: mappingTemplates.exactStringNotIndexed,
+    serialPublicationDates: mappingTemplates.exactStringNotIndexed,
     subjectLiteral: mappingTemplates.fulltextWithRaw,
-    // status: mappingTemplates.entity,
-    // status_packed: {'type': 'string', 'index': 'not_analyzed'},
     subject_packed: mappingTemplates.packed,
     supplementaryContent: {
       type: 'object',
@@ -242,7 +302,7 @@ var prepareResourcesIndex = (indexName, deleteIfExists) => {
       } // body
     }).then(() => {
       log.info('Putting new ' + indexName + ' mapping')
-      var body = { resource: { properties: common_properties } }
+      var body = { resource: { properties: resourcesProperties } }
       return client().indices.putMapping({ index: indexName, type: 'resource', body: body })
     })
   })


### PR DESCRIPTION
This updates the section in lib/index.js that establishes the baseline
resources index mapping. This is only used when building a brand new
index, but serves secondarily as documentation of the ES schema. Several
new properties have been added lately without updating this mapping.
This commit corrects that as well as cleans it up with fresh
inline documentation.