### PR TITLE
Change how items are sorted by box/v. in shelfmark

### DIFF
--- a/lib/es-serializer.js
+++ b/lib/es-serializer.js
@@ -241,8 +241,8 @@ class ResourceSerializer extends EsSerializer {
             // If we have callnumbers, order by those:
             if (i1['shelfMark'] && i2['shelfMark']) {
               // zero-pad trailing integers (box / tube /vol number)
-              var shelfMark1 = zeroPadVolumeSuffix(i1['shelfMark'][0])
-              var shelfMark2 = zeroPadVolumeSuffix(i2['shelfMark'][0])
+              var shelfMark1 = ResourceSerializer.sortableShelfMark(i1['shelfMark'][0])
+              var shelfMark2 = ResourceSerializer.sortableShelfMark(i2['shelfMark'][0])
               return shelfMark1 > shelfMark2 ? 1 : -1
 
             // Otherwise, order by id:
@@ -265,12 +265,34 @@ class ResourceSerializer extends EsSerializer {
  * e.g.:
  *  "*T-Mss 1991-010 Box 27" ==> "*T-Mss 1991-010 Box 000027"
  *   "*T-Mss 1991-010 Tube 70" ==> "*T-Mss 1991-010 Tube 000070"
+ *
+ * In addition to padding terminating numbers, any number following one of
+ * these sequences anywhere in the string, case-insensitive, is padded:
+ *  - box
+ *  - tube
+ *  - v.
+ *  - no.
+ *  - r.
  */
-function zeroPadVolumeSuffix (shelfMark) {
-  // Assume box and tube numbers never exceed 999,999:
-  var padLen = 6
-  return shelfMark.replace(/\d+$/, (s) => (new Array(Math.max(0, (padLen - s.length) + 1))).join('0') + s)
+ResourceSerializer.sortableShelfMark = (shelfMark) => {
+  // NodeJS doesn't have lookbehinds, so fake it with replace callback:
+  const reg = /(\d+$|((^|\s)(box|v\.|no\.|r\.|box|tube) )(\d+))/i
+  // This callback will receive all matches:
+  const replace = (m0, fullMatch, label, labelWhitespace, labelText, number) => {
+    // If we matched a label, build string from label and then pad number
+    return label ? `${label.toLowerCase()}${ResourceSerializer.zeroPadString(number)}`
+    // Otherwise just pad whole match (presumably it's a line terminating num):
+      : ResourceSerializer.zeroPadString(fullMatch)
+  }
+  return shelfMark
+    .replace(reg, replace)
+    .replace(/\s{2,}/g, ' ')
 }
+
+/**
+ * Returns a '0' left-padded string to default length of 6
+ */
+ResourceSerializer.zeroPadString = (s, padLen = 6) => (new Array(Math.max(0, (padLen - s.length) + 1))).join('0') + s
 
 ResourceSerializer.serialize = (resource) => (new ResourceSerializer(resource)).serialize()
 

--- a/lib/es-serializer.js
+++ b/lib/es-serializer.js
@@ -259,12 +259,21 @@ class ResourceSerializer extends EsSerializer {
   }
 }
 
-/* Takes a shelfMark, returns a sortable shelfMark
- * Basically just zero-pads any trailing integer (assuming item shelfMarks look like ".. Box 1", ".. Tube 91")
+/**
+ * Get a sortable shelfmark value by collapsing whitespace and zero-padding
+ * anything that looks like a box, volume, or tube number, identified as:
+ *  - any number terminating the string, or
+ *  - any number following known prefixes (e.g. box, tube, v., etc).
+ *
+ * If number is identified by prefix (e.g. box, tube), prefix will be made
+ * lowercase.
+ *
+ * @return {string} A sortable version of the given shelfmark
  *
  * e.g.:
- *  "*T-Mss 1991-010 Box 27" ==> "*T-Mss 1991-010 Box 000027"
- *   "*T-Mss 1991-010 Tube 70" ==> "*T-Mss 1991-010 Tube 000070"
+ *  "*T-Mss 1991-010   Box 27" ==> "*T-Mss 1991-010 box 000027"
+ *  "*T-Mss 1991-010   Tube 70" ==> "*T-Mss 1991-010 tube 000070"
+ *  "Map Div. 98­914    Box 25, Wi­Z')" ==> "Map Div. 98­914 box 000025, Wi­Z')"
  *
  * In addition to padding terminating numbers, any number following one of
  * these sequences anywhere in the string, case-insensitive, is padded:
@@ -286,6 +295,7 @@ ResourceSerializer.sortableShelfMark = (shelfMark) => {
   }
   return shelfMark
     .replace(reg, replace)
+    // Collapse redundant whitespace:
     .replace(/\s{2,}/g, ' ')
 }
 

--- a/test/bib-serializations-test.js
+++ b/test/bib-serializations-test.js
@@ -434,4 +434,40 @@ describe.only('Bib Serializations', function () {
       })
     })
   })
+
+  describe('item order', function () {
+    it('ResourceSerializer.zeroPadString should zero pad a string', function () {
+      assert.equal(ResourceSerializer.zeroPadString('78'), '000078')
+    })
+
+    it('ResourceSerializer.sortableShelfMark zero-pads numbers at end of string', function () {
+      let sortable = ResourceSerializer.sortableShelfMark
+
+      // Test numbers that *terminate* a call number:
+      assert.equal(sortable('T-Mss 1991-010 27'), 'T-Mss 1991-010 000027')
+      assert.equal(sortable('T-Mss 1991-010 70'), 'T-Mss 1991-010 000070')
+    })
+
+    it('ResourceSerializer.sortableShelfMark makes sortable vol/reel/box/tube numbers wherever they appear', function () {
+      let sortable = ResourceSerializer.sortableShelfMark
+
+      // Test numbers that appear anywhere within a call number:
+      // Test box/Box/BOX:
+      assert.equal(sortable('Map Div. 98­914    Box 9, Fj­Ga'), 'Map Div. 98­914 box 000009, Fj­Ga')
+      assert.equal(sortable('Map Div. 98­914    box 9, Fj­Ga'), 'Map Div. 98­914 box 000009, Fj­Ga')
+      assert.equal(sortable('Map Div. 98­914    BOX 9, Fj­Ga'), 'Map Div. 98­914 box 000009, Fj­Ga')
+
+      assert.equal(sortable('Map Div. 98­914    Box 8, E­Fi'), 'Map Div. 98­914 box 000008, E­Fi')
+      assert.equal(sortable('Map Div. 98­914  Box 17, Mp­O'), 'Map Div. 98­914 box 000017, Mp­O')
+      // Box 8 should precede Box 25:
+      assert(sortable('Map Div. 98­914    Box 8, E­Fi') < sortable('Map Div. 98­914    Box 25, Wi­Z'))
+      // Confirm the whitespace collapse causes Box 25 to follow box 17 regardless of whitespace:
+      assert(sortable('Map Div. 98­914    Box 25, Wi­Z') > sortable('Map Div. 98­914  Box 17, Mp­O'))
+
+      assert.equal(sortable('Map Div. 98­914    v. 8, E­Fi'), 'Map Div. 98­914 v. 000008, E­Fi')
+      assert.equal(sortable('Map Div. 98­914    TUBE 8, E­Fi'), 'Map Div. 98­914 tube 000008, E­Fi')
+      assert.equal(sortable('Map Div. 98­914    No. 8, E­Fi'), 'Map Div. 98­914 no. 000008, E­Fi')
+      assert.equal(sortable('Map Div. 98­914    r. 8, E­Fi'), 'Map Div. 98­914 r. 000008, E­Fi')
+    })
+  })
 })


### PR DESCRIPTION
This changes how the sortable version of the shelfmark is built to
ensure that box/vol/reel numbers occuring mid-string are
'0'-padded. It looks for labels (e.g. box, v., r.) case-insensitively
and ensures differently-cased labels are compared as lowercase (so that
'Box 1' doesn't follow 'box 2', for example). Adds tests.

https://jira.nypl.org/browse/SCC-263