### PR TITLE
Bump discovery-store-models to fix item object_type

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "aws-sdk": "^2.53.0",
     "blessed": "^0.1.81",
     "blessed-contrib": "^3.5.5",
-    "discovery-store-models": "https://github.com/NYPL-discovery/discovery-store-models.git#v1.2.0",
+    "discovery-store-models": "https://github.com/NYPL-discovery/discovery-store-models.git#v1.2.1",
     "dotenv": "^4.0.0",
     "elasticsearch": "^13.0.1",
     "fast-csv": "^2.3.0",


### PR DESCRIPTION
Bumps discovery-store-models to v1.2.1, incorporating fix to surface
object_type in Item instances.

https://github.com/NYPL-discovery/discovery-store-models/pull/4