### PR TITLE
Adds a few helper scripts for indexing, debugging

### DIFF
--- a/lib/env-config-helper.js
+++ b/lib/env-config-helper.js
@@ -61,7 +61,6 @@ function init (clients) {
 
   if (clients.log) {
     clients.log.setLevel(process.env.LOGLEVEL || 'info')
-    clients.log.info('Writing to ' + indexName)
   }
 
   return (initializations.length > 0 ? Promise.all(initializations) : Promise.resolve())

--- a/lib/index.js
+++ b/lib/index.js
@@ -556,8 +556,11 @@ var _indexGeneric = function (indexName, records, update) {
 }
 
 const search = (params) => {
-  // console.log('searching: ', JSON.stringify(params.body, null, 2))
   return client().search(params)
+}
+
+const scroll = (params) => {
+  return client().scroll(params)
 }
 
 // Submit given array of 'resource' doc updates to elastic search as INSERTS/OVERWRITES
@@ -679,6 +682,7 @@ module.exports = {
     indexIsActive
   },
   search,
+  scroll,
   setConnection: setConnection,
   connected
 }

--- a/scripts/data/.gitignore
+++ b/scripts/data/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/scripts/identify-ids-by-query.js
+++ b/scripts/identify-ids-by-query.js
@@ -1,0 +1,100 @@
+/**
+ * This script takes a query (sample below) and collects all matching ids.
+ * The result is written to ./data/identify-ids-by-query-out.csv
+ *
+ * Usage:
+ *  - Modify the ES Query below
+ *  - Run node scripts/identify-ids-by-query --profile [aws profile] --envfile [env file with relevant creds]
+ *  - Check scripts/data/identify-ids-by-query-out.json for result
+ */
+
+const fs = require('fs')
+const index = require('../lib/index')
+const envConfigHelper = require('../lib/env-config-helper')
+
+const PER_PAGE = 500
+
+/**
+ * ES Query:
+ * This query will be used to identify records:
+ */
+const params = {
+  body: {
+    query: {
+      nested: {
+        path: 'items',
+        query: {
+          regexp: {
+            'items.identifier': {
+              value: '[0-9]+'
+            }
+          }
+        }
+      }
+    },
+    sort: [ 'uri' ],
+    size: PER_PAGE,
+    _source: false
+  }
+}
+
+/**
+ * Recursive step. Given a raw search result, calls `scroll` until all records
+ * consumed.
+ *
+ * @returns {Promise<String[]>} Promise that resolves an array of matching ids.
+ */
+function parseResultAndScroll (result, records = []) {
+  const ids = result.hits.hits.map((h) => h._id)
+  records = records.concat(ids)
+
+  if (records.length < result.hits.total) {
+    const page = Math.ceil(records.length / PER_PAGE)
+    const pages = Math.ceil(result.hits.total / PER_PAGE)
+    console.log(`Scrolling: ${page} of ${pages}`)
+    return index.scroll({ scrollId: result._scroll_id, scroll: '30s' })
+      .then((result) => parseResultAndScroll(result, records))
+  } else {
+    return records
+  }
+}
+
+/**
+ * Given an ES query, performs query, returning ids
+ *
+ * @returns {Promise<String[]>} Promise that resolves an array of matching ids.
+ */
+function fetch (params, records = []) {
+  return index.search(params)
+    .then(parseResultAndScroll)
+}
+
+envConfigHelper.init({ index })
+  .then(() => {
+    params.index = process.env.ELASTIC_RESOURCES_INDEX_NAME
+    params.scroll = '30s'
+
+    fetch(params).then((result) => {
+      // Write to a CSV with four cols:
+      //  - type (bib/item)
+      //  - nyplSource (e.g. sierra-nypl, recap-pul)
+      //  - id (e.g. 100)
+      //  - uri (e.g. b100)
+      const outpath = './scripts/data/identify-ids-by-query-out.csv'
+      console.log(`Got ${result.length} results. Writing to ${outpath}`)
+
+      // Map to nyplSource and numeric id:
+      result = result.map((uri) => {
+        const idParts = uri.match(/([bpc]{1,2})(\d+)/)
+        const nyplSource = {
+          b: 'sierra-nypl',
+          pb: 'recap-pul',
+          cb: 'recap-cul'
+        }[idParts[1]]
+        const id = idParts[2]
+        return [ 'bib', nyplSource, id, uri ]
+      })
+
+      fs.writeFileSync(outpath, result.join('\n'))
+    })
+  })

--- a/scripts/print-serialized.js
+++ b/scripts/print-serialized.js
@@ -1,0 +1,34 @@
+/**
+ * Helper script for printing the index serialization of any record.
+ *
+ * Usage
+ *
+ * node scripts/print-serialized --bnum [bnum] --profile [aws profile] \
+ *   --envfile [path to local db creds file]
+ */
+
+const DiscoveryModels = require('discovery-store-models')
+
+const ResourceSerializer = require('../lib/es-serializer').ResourceSerializer
+const envConfigHelper = require('../lib/env-config-helper')
+
+// Parsc cmd line opts:
+var argv = require('optimist')
+  .usage('Index resources index with various types\nUsage: $0 -type TYPE')
+  .default({
+    bnum: null
+  })
+  .describe('bnum', 'Specify single bnum to display')
+  .argv
+
+// Get serialization for single bib:
+if (argv.bnum) {
+  envConfigHelper.init({ discoveryStoreModels: DiscoveryModels })
+    .then(() => DiscoveryModels.Bib.byId(argv.bnum))
+    .then(ResourceSerializer.serialize)
+    .then((doc) => {
+      // console.info(JSON.stringify(doc, null, 2))
+      process.stdout.write(JSON.stringify(doc, null, 2))
+      process.exit()
+    })
+}

--- a/scripts/write-to-index-document-stream-from-file.js
+++ b/scripts/write-to-index-document-stream-from-file.js
@@ -1,0 +1,92 @@
+/**
+ * Script to write bulk records into IndexDocumentQueue[-env]
+ *
+ * If you have a CSV of uris you'd like to reindex (because they're represented
+ * well in the store, but are mis-represented in the ES index), this is the
+ * script for you.
+ *
+ * Usage:
+ *   node scripts/write-to-index-document-stream-from-file \
+ *     --envfile config/qa.env --profile nypl-sandbox \
+ *     [--infile [path to local 4-col csv]] \
+ *     [--infileUriColumn N]
+ *
+ * @example
+ * // This will read data from ./scripts/data/identify-ids-by-query-out.csv
+ * // and write uris from col 3 (0 ind) to IndexDocumentQueue:
+ * node scripts/write-to-index-document-stream-from-file --envfile config/qa.env --profile nypl-sandbox
+ */
+
+const fs = require('fs')
+const minimist = require('minimist')
+const NyplStreamsClient = require('@nypl/nypl-streams-client')
+var log = require('loglevel')
+
+const envConfigHelper = require('../lib/env-config-helper')
+
+const argv = minimist(process.argv, {
+  default: {
+    streamName: 'IndexDocumentQueue',
+    offset: 0,
+    // CSV to read from:
+    infile: './scripts/data/identify-ids-by-query-out.csv',
+    // Column index (0-indexed) were we can find the "uri" value:
+    infileUriColumn: 3
+  }
+})
+
+const streamsClient = new NyplStreamsClient({ nyplDataApiClientBase: process.env['NYPL_API_BASE_URL'], logLevel: 'error' })
+
+/**
+ * Write {records} to {streamName} after encoding them against {schemaName}
+ */
+const writeToStreamsClient = (streamName, records, schemaName) => {
+  return streamsClient.write(streamName, records, { avroSchemaName: schemaName })
+    .then((response) => {
+      if (response.FailedRecordCount > 0) {
+        var responseRecords = response.Records
+        var failedRecords = []
+        for (var i = 0; i < responseRecords.length; i++) {
+          if (responseRecords[i].ErrorCode) {
+            failedRecords.push(records[i])
+          }
+        }
+        return writeToStreamsClient(streamName, failedRecords, schemaName)
+      }
+      return Promise.resolve(response)
+    })
+    .catch((error) => {
+      log.error('Error occurred while posting to kinesis')
+      return Promise.reject(error)
+    })
+}
+
+envConfigHelper.init({ })
+  .then(() => {
+    let records = fs.readFileSync(argv.infile, 'utf8')
+      .split('\n')
+      .map((row) => row.split(','))
+      .map((row, ind) => {
+        if (!row) throw new Error(`Failed at row ${ind}: Row empty/null: ${row}`)
+        if (!row[argv.infileUriColumn]) throw new Error(`Failed at row ${ind}: Column index ${argv.infileUriColumn} empty/null: ${row[argv.infileUriColumn]}`)
+
+        return { type: 'record', uri: row[argv.infileUriColumn] }
+      })
+
+    // Log what we're doing:
+    console.log([
+      'Processing',
+      argv.limit ? ` ${argv.limit}` : ' ALL',
+      ` of ${records.length} total records`,
+      argv.offset ? ` starting at offset ${argv.offset}` : ''
+    ].join(''))
+
+    // Slice to specified range:
+    if (argv.limit || argv.offset) records = records.slice(argv.offset, argv.offset + argv.limit || records.length)
+
+    console.log(`Writing ${records.length} records to ${argv.streamName}`)
+    return writeToStreamsClient(argv.streamName, records, 'IndexDocumentQueue')
+      .then(() => {
+        console.log(`Done writing ${records.length} to stream.`)
+      })
+  })


### PR DESCRIPTION
Adds scripts folder with three new scripts:
 - identifiy-ids-by-query: Given an ES query (established inline),
   queries the configured ES index and writes identifiers for matching
   resources to a CSV
 - write-to-index-document-stream-from-file: Counterpart to above, reads
   resource identifiers from a CSV and writes them to the specified
   IndexDocumentQueue stream (in effect forcing them to be re-indexed.
 - print-serialized: Given a bnumber, pulls data from the store,
   produces an ES document serialization, and prints it to the console.
   Useful for ad hoc verification.