### PR TITLE
Add integ test for contentsTitle matching, cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "deploy-qa": "./node_modules/.bin/node-lambda deploy -e qa -f ./config/qa.env -b subnet-f4fe56af -g sg-1d544067 --role arn:aws:iam::224280085904:role/lambda_basic_execution --profile nypl-sandbox -S ./config/event-sources-qa.json",
     "deploy-production": "./node_modules/.bin/node-lambda deploy -e production -f ./config/production.env -b subnet-59bcdd03,subnet-5deecd15 -g sg-116eeb60 --role arn:aws:iam::946183545209:role/lambda-full-access --profile nypl-digital-dev -S ./config/event-sources-production.json",
     "run-qa": "AWS_PROFILE=nypl-sandbox ./node_modules/.bin/node-lambda run -f ./config/qa.env",
-    "prepare-query-test-index": "NYPL_CORE_VERSION=4da5696b5ad135eeb237a219af19c35a6e633658 node ./jobs/prepare-query-test-index --profile nypl-sandbox --envfile config/qa.env",
+    "prepare-query-test-index": "node ./jobs/prepare-query-test-index --profile nypl-sandbox --envfile config/qa.env",
     "run-query-tests": "./node_modules/.bin/mocha ./test/query-tests --profile nypl-sandbox --envfile config/qa.env"
   },
   "description": "Listens to IndexDocument[-env], pulls data from discovery-store, writes it to ES, notifies IndexDocumentProcessed[-env]",

--- a/test/query-tests/keyword.test.js
+++ b/test/query-tests/keyword.test.js
@@ -13,11 +13,13 @@ const keywordQuery = (term, searchScope = 'all') => {
   switch (searchScope) {
     case 'title':
       customFields = [
-        'title.folded^5',
-        'seriesStatement.folded',
+        'title^5',
+        'title.folded^2',
         'titleAlt.folded',
         'uniformTitle.folded',
-        'titleDisplay.folded'
+        'titleDisplay.folded',
+        'seriesStatement.folded',
+        'contentsTitle'
       ]
       break
     case 'contributor':
@@ -50,16 +52,20 @@ const keywordQuery = (term, searchScope = 'all') => {
       break
     default:
       customFields = [
-        'title.folded^5',
+        'title^5',
+        'title.folded^2',
         'description.folded',
+        'subjectLiteral^2',
         'subjectLiteral.folded',
+        'creatorLiteral^2',
         'creatorLiteral.folded',
         'contributorLiteral.folded',
         'note.label.folded',
         'publisherLiteral.folded',
         'seriesStatement.folded',
         'titleAlt.folded',
-        'titleDisplay.folded'
+        'titleDisplay.folded',
+        'contentsTitle.folded'
       ]
   }
 
@@ -603,6 +609,18 @@ describe('Keyword querying', function () {
           expect(result.hits.total).to.equal(1)
           expect(result.hits.hits[0]).to.be.a('object')
           expect(result.hits.hits[0]._id).to.equal('b10001936')
+        })
+      })
+    })
+
+    describe('Contents title', function () {
+      it('should match b11055155 by contrib', function () {
+        return search(keywordQuery('Theban temples')).then((result) => {
+          expect(result).to.be.a('object')
+          expect(result.hits).to.be.a('object')
+          expect(result.hits.total).to.equal(1)
+          expect(result.hits.hits[0]).to.be.a('object')
+          expect(result.hits.hits[0]._id).to.equal('b11055155')
         })
       })
     })


### PR DESCRIPTION
Adds integration test for matching a specific test document using
contentsTitle field in default and title scoped search.

Also updates the fields matched for all keyword queries to match the
fields presently matched by discovery-api - so that the tests run here
best emulate the query body produced by discovery-api. Also removes
now-unnecessary NYPL_CORE_VERSION override in registered run-query-tests
package script (nypl-core master now contains all mappings that these
tests rely upon).