### PR TITLE
Fix bug where deleted records not deleted from ES

### DIFF
--- a/kinesify-data.js
+++ b/kinesify-data.js
@@ -18,7 +18,7 @@ const argv = require('minimist')(process.argv.slice(2))
 // config
 const infile = argv._[0] || 'event.unencoded.json'
 const outfile = argv._[1] || 'event.json'
-const schemaUrl = argv._[2] || 'https://api.nypltech.org/api/v0.1/current-schemas/IndexDocument'
+const schemaUrl = argv._[2] || 'https://platform.nypl.org/api/v0.1/current-schemas/IndexDocument'
 
 function onSchemaLoad (schema) {
   // initialize avro schema

--- a/lib/resource-indexer.js
+++ b/lib/resource-indexer.js
@@ -63,15 +63,12 @@ function handleSuppression (record) {
   if (deleteResource) {
     // Delete from index (in case previously not suppressed
     // Resolve `null` to indicate it should not be saved
-    return index.resources.delete(process.env['ELASTIC_RESOURCES_INDEX_NAME'], record.uri)
+    return deleteResourceByUri(record.uri, { suppressErrors: true })
       .then((res) => {
-        return true
-      })
-      .catch((e) => {
-        if (e.status === 404) log.debug('Failed to delete ' + record.uri + ' because it does not exist')
-        else log.debug('Failed to delete ' + record.uri, e)
-        // Return suppressed==true even if failed to delete record because likely 404
-        // and we mainly want to prevent further processing
+        // Return `true` to indicate record was suppressed even if it errored
+        // (note `suppressErrors: true` option above)
+        // because likely issue is a 404 and we mainly want to prevent
+        // further processing
         return true
       })
   }
@@ -79,10 +76,45 @@ function handleSuppression (record) {
   return Promise.resolve(false)
 }
 
-// This call does all the work of suppressing/updating index using given stream of Bib instances
-// It returns a stream with one item holding:
-//  * savedCount: Num saved
-//  * suppressedCount: Num suppressed (or not saved)
+function deleteResourceByUri (uri, options = { suppressErrors: true }) {
+  return index.resources.delete(process.env['ELASTIC_RESOURCES_INDEX_NAME'], uri)
+    // Suppress errors when deleting records because it's likely a 404
+    .catch((e) => {
+      if (!options.suppressErrors) throw e
+
+      if (e.status === 404) log.debug(`Failed to delete ${uri} because it does not exist`)
+      else log.debug(`Failed to delete ${uri}`, e)
+    })
+}
+
+/**
+ *  @typedef {Object} ProcessStreamOfBibsOptions
+ *  @property {boolean} notifyDocumentProcessed - If true, will attempt to
+ *    broadcast to DocumentProcessed stream
+ *  @property {function } onBatchComplete - Callback to fire over successive
+ *    batches. Default `() => null`
+ *  @property {function } onBibSuppressed - Callback to fire when a suppression
+ *    occurs. Default `() => null`
+ */
+
+/**
+ *  @typedef {Object} ProcessStreamOfBibsResult
+ *  @property {integer} savedCount - Number saved
+ *  @property {integer} suppressedCount - Number suppressed (or not saved)
+ *  @property {array<string>} updatedUris - Array of uris (ids with prefixes)
+ */
+
+/**
+ *  This call does all the work of suppressing/updating index using given
+ *  stream of Bib instances.
+ *
+ *  @param {HighlandStream} stream - Stream of records to process
+ *  @param {ProcessStreamOfBibsOptions} opts
+ *
+ *  @returns {HighlandStream<ProcessStreamOfBibsResult>} - A stream instance
+ *    with a single ProcessStreamOfBibsResult item
+ *
+ */
 function processStreamOfBibs (stream, opts) {
   opts = Object.assign({
     notifyDocumentProcessed: true,
@@ -91,6 +123,7 @@ function processStreamOfBibs (stream, opts) {
   }, opts || {})
 
   var suppressedCount = 0
+  let updatedUris = []
 
   return stream
     // Suppress bibs that should be suppressed due to record suppression or to being non-research
@@ -126,6 +159,9 @@ function processStreamOfBibs (stream, opts) {
       // otherwise resolve immediately:
       return (opts.notifyDocumentProcessed ? notifyIndexDocumentProcessed(resources) : Promise.resolve())
         .then(() => opts.onBatchComplete(resources.length))
+        .then(() => {
+          updatedUris = updatedUris.concat(resources.map((resource) => resource.uri))
+        })
         .then(() => ({ count: resources.length }))
     })
     .flatMap((h) => _(h))
@@ -134,9 +170,10 @@ function processStreamOfBibs (stream, opts) {
     .map((savedCount) => {
       return {
         savedCount,
-        suppressedCount
+        suppressedCount,
+        updatedUris
       }
     })
 }
 
-module.exports = { processStreamOfBibs }
+module.exports = { processStreamOfBibs, deleteResourceByUri }

--- a/lib/resource-indexer.js
+++ b/lib/resource-indexer.js
@@ -8,7 +8,10 @@ const index = require('./index')
 const ResourceSerializer = require('./es-serializer').ResourceSerializer
 
 const OUTGOING_SCHEMA_NAME = process.env['OUTGOING_SCHEMA_NAME'] || 'IndexDocumentProcessed'
-const OUTGOING_STREAM_NAME = process.env['OUTGOING_STREAM_NAME'] || 'IndexDocumentProcessed'
+const OUTGOING_STREAM_NAME = process.env['OUTGOING_STREAM_NAME']
+
+const DiscoveryStoreModels = require('discovery-store-models')
+const { Bib } = DiscoveryStoreModels
 
 function writeResourcesToIndex (resources) {
   log.debug('Saving batch of ' + resources.length + 'resources', resources)
@@ -20,6 +23,11 @@ function writeResourcesToIndex (resources) {
 }
 
 function notifyIndexDocumentProcessed (resources) {
+  if (!OUTGOING_STREAM_NAME) {
+    log.warn('Attempting to notify IndexDocumentProcessed stream, but no stream configured')
+    return Promise.resolve()
+  }
+
   // Build records to post to stream:
   var indexDocumentProcessedRecords = resources.map((resource) => {
     // Set nyplSource based on uri prefix:
@@ -100,8 +108,8 @@ function deleteResourceByUri (uri, options = { suppressErrors: true }) {
 /**
  *  @typedef {Object} ProcessStreamOfBibsResult
  *  @property {integer} savedCount - Number saved
- *  @property {integer} suppressedCount - Number suppressed (or not saved)
- *  @property {array<string>} updatedUris - Array of uris (ids with prefixes)
+ *  @property {integer} suppressedUris - Number suppressed (or not saved)
+ *  @property {array<string>} savedUris - Array of uris (ids with prefixes)
  */
 
 /**
@@ -122,16 +130,16 @@ function processStreamOfBibs (stream, opts) {
     onBibSuppressed: (bib) => null
   }, opts || {})
 
-  var suppressedCount = 0
-  let updatedUris = []
+  var suppressedUris = []
+  let savedUris = []
 
   return stream
     // Suppress bibs that should be suppressed due to record suppression or to being non-research
     .map((record) => handleSuppression(record)
       .then((suppressed) => {
         if (suppressed) {
-          // Keep track of number suppressed:
-          suppressedCount += 1
+          // Keep track of suppressed uris:
+          suppressedUris.push(record.uri)
 
           // Notify caller that bib was suppressed (IF IT EVEN CARES GAWD):
           opts.onBibSuppressed(record)
@@ -160,7 +168,7 @@ function processStreamOfBibs (stream, opts) {
       return (opts.notifyDocumentProcessed ? notifyIndexDocumentProcessed(resources) : Promise.resolve())
         .then(() => opts.onBatchComplete(resources.length))
         .then(() => {
-          updatedUris = updatedUris.concat(resources.map((resource) => resource.uri))
+          savedUris = savedUris.concat(resources.map((resource) => resource.uri))
         })
         .then(() => ({ count: resources.length }))
     })
@@ -170,10 +178,101 @@ function processStreamOfBibs (stream, opts) {
     .map((savedCount) => {
       return {
         savedCount,
-        suppressedCount,
-        updatedUris
+        savedUris,
+        suppressedCount: suppressedUris.length,
+        suppressedUris
       }
     })
 }
 
-module.exports = { processStreamOfBibs, deleteResourceByUri }
+// Given an array of uris (bnums), returns a Promise that resolves multiple raw results
+function getResourceStatements (uris) {
+  // Make sure it's an array:
+  uris = Array.isArray(uris) ? uris : [uris]
+  // Make sure none are repeated:
+  uris = Object.keys(uris.reduce((h, uri) => {
+    h[uri] = true
+    return h
+  }, {}))
+  log.info('Fetching statements for ' + uris.join(', '))
+  // Get bibs:
+  return Bib.byIds(uris)
+    .catch((e) => {
+      // If it's just a bad bib id, quiet failure:
+      if (e.name === 'QueryResultError') {
+        log.info('Invalid bib ids: ' + uris + '. Moving on.')
+
+        return []
+      // Otherwise: throw error to stop all execution because it's probably not record specific:
+      } else throw e
+    })
+}
+
+/**
+ * Process an array of bib ids. Retrieves objects from database, performs
+ * suppressions and other deletions, updates documents in the index, and
+ * notifies relevant streams.
+ *
+ * @param {array<string>} ids - Array of ids (e.g. ['b1234', 'b5678'])
+ */
+function processArrayOfBibUris (ids) {
+  let result = {}
+
+  // This call does all the work of suppressing/updating index using given stream of Bib instances
+  // It returns a stream with one item giving stats
+  return new Promise((resolve, reject) => {
+    // index each document
+    var stream = _(ids)
+      // Flatten stream to array:
+      .reduce([], (a, uri) => a.concat([uri]))
+      // Look up statements by uri
+      .map(getResourceStatements)
+      .flatMap((h) => _(h))
+      .map((bibs) => {
+        // Now that we've fetched all retrievable records from the
+        // store, identify records that were not retrieved from store
+        // (either because they were deleted or never existed) and make sure
+        // they do not exist in index:
+        const validUris = bibs.map((bib) => bib.uri)
+        const deleteUris = ids
+          .filter((id) => validUris.indexOf(id) < 0)
+
+        if (deleteUris.length > 0) {
+          log.info(`Issuing DELETE on invalid bibids: ${deleteUris}`)
+          result.deletedUris = deleteUris
+          result.deletedCount = deleteUris.length
+
+          return Promise.all(deleteUris.map((uri) => deleteResourceByUri(uri, { suppressErrors: true })))
+            .then(() => bibs)
+        }
+
+        return Promise.resolve(bibs)
+      })
+      .flatMap((h) => _(h))
+      // Now that we've the fetched bibs in a single array, feed them one by one into the stream:
+      .sequence()
+      // Strip missing (null) records
+      .compact()
+
+    processStreamOfBibs(stream)
+      .map((_result) => {
+        // Gather all aggregates together into a single object with:
+        //  * savedUris, savedCount - Documents updated
+        //  * suppressedUris, suppressedCount - Documents hidden because
+        //      something in the bib/item data indicates it is "suppressed"
+        //  * deletedUris, deletedCount - Documents deleted because they
+        //      weren't retrievable from the store.
+        result = Object.assign(result, _result)
+      })
+      .stopOnError((e) => {
+        reject(e)
+      })
+      .done(() => {
+        log.info('Completed processing ' + result.savedCount + ' doc(s)')
+        if (result.suppressedCount) log.info('  Suppressed ' + result.suppressedCount + ' doc(s)')
+        resolve(result)
+      })
+  })
+}
+
+module.exports = { processArrayOfBibUris, processStreamOfBibs, deleteResourceByUri }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "resolved": "https://registry.npmjs.org/@nypl/nypl-core-objects/-/nypl-core-objects-1.3.1.tgz",
       "integrity": "sha1-KKZn+nVXYdoEVnQkfWpsgqdUs34=",
       "requires": {
-        "jsonld": "0.4.12",
-        "just-flatten": "1.0.0",
-        "sync-request": "4.1.0"
+        "jsonld": "^0.4.5",
+        "just-flatten": "^1.0.0",
+        "sync-request": "^4.1.0"
       }
     },
     "@nypl/nypl-data-api-client": {
@@ -19,10 +19,10 @@
       "resolved": "https://registry.npmjs.org/@nypl/nypl-data-api-client/-/nypl-data-api-client-0.1.1.tgz",
       "integrity": "sha1-NhSuPBViuP/kaabj5p1Foy9Xrsw=",
       "requires": {
-        "loglevel": "1.6.1",
-        "node-cache": "4.2.0",
-        "oauth": "0.9.15",
-        "request": "2.86.0"
+        "loglevel": "^1.4.1",
+        "node-cache": "^4.1.1",
+        "oauth": "^0.9.15",
+        "request": "^2.81.0"
       }
     },
     "@nypl/nypl-streams-client": {
@@ -30,40 +30,55 @@
       "resolved": "https://registry.npmjs.org/@nypl/nypl-streams-client/-/nypl-streams-client-0.1.4.tgz",
       "integrity": "sha1-/vYIIhtkz4GR4nQ35rlbIeIxno8=",
       "requires": {
-        "@nypl/nypl-data-api-client": "0.1.1",
-        "avsc": "5.2.3",
-        "aws-sdk": "2.241.1",
-        "loglevel": "1.6.1",
-        "minimist": "1.2.0"
+        "@nypl/nypl-data-api-client": "^0.1.1",
+        "avsc": "^5.0.2",
+        "aws-sdk": "^2.50.0",
+        "loglevel": "^1.4.1",
+        "minimist": "^1.2.0"
+      }
+    },
+    "@sinonjs/commons": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
+      "integrity": "sha512-WR3dlgqJP4QNrLC4iXN/5/2WaLQQ0VijOOkmflqFGVJ6wLEpbSjo7c0ZeGIdtY8Crk7xBBp87sM6+Mkerz7alw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
       }
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "integrity": "sha1-hNt+nrVTHfGKjF4L+25EnlXmVLI=",
       "dev": true,
       "requires": {
         "samsam": "1.3.0"
       }
+    },
+    "@sinonjs/samsam": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.0.0.tgz",
+      "integrity": "sha512-D7VxhADdZbDJ0HjUTMnSQ5xIGb4H2yWpg8k9Sf1T08zfFiQYlaxM8LZydpR4FQ2E6LZJX8IlabNZ5io4vdChwg==",
+      "dev": true
     },
     "JSONStream": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
       "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
       "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
       }
     },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg="
     },
     "acorn": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+      "integrity": "sha1-9HPdR+AnegjijpvsWu6wR1HwuMk=",
       "dev": true
     },
     "acorn-jsx": {
@@ -72,7 +87,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -86,10 +101,10 @@
     "agent-base": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
-      "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+      "integrity": "sha1-mDi1wzkrliutAx5qTF4QJKvsRc4=",
       "dev": true,
       "requires": {
-        "es6-promisify": "5.0.0"
+        "es6-promisify": "^5.0.0"
       }
     },
     "agentkeepalive": {
@@ -102,10 +117,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ajv-keywords": {
@@ -135,7 +150,7 @@
       "resolved": "https://registry.npmjs.org/ansi-term/-/ansi-term-0.0.2.tgz",
       "integrity": "sha1-/XU++kvq2g6smZgbxSo/b/AZ3rc=",
       "requires": {
-        "x256": "0.0.2"
+        "x256": ">=0.0.1"
       }
     },
     "ansicolors": {
@@ -149,23 +164,23 @@
       "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
       "dev": true,
       "requires": {
-        "archiver-utils": "1.3.0",
-        "async": "2.6.0",
-        "buffer-crc32": "0.2.13",
-        "glob": "7.1.1",
-        "lodash": "4.17.10",
-        "readable-stream": "2.3.6",
-        "tar-stream": "1.6.1",
-        "zip-stream": "1.2.0"
+        "archiver-utils": "^1.3.0",
+        "async": "^2.0.0",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.0.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0",
+        "tar-stream": "^1.5.0",
+        "zip-stream": "^1.2.0"
       },
       "dependencies": {
         "async": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
           "dev": true,
           "requires": {
-            "lodash": "4.17.10"
+            "lodash": "^4.14.0"
           }
         }
       }
@@ -176,21 +191,21 @@
       "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
       "dev": true,
       "requires": {
-        "glob": "7.1.1",
-        "graceful-fs": "4.1.11",
-        "lazystream": "1.0.0",
-        "lodash": "4.17.10",
-        "normalize-path": "2.1.1",
-        "readable-stream": "2.3.6"
+        "glob": "^7.0.0",
+        "graceful-fs": "^4.1.0",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.8.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
       }
     },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arguments-extended": {
@@ -198,8 +213,8 @@
       "resolved": "https://registry.npmjs.org/arguments-extended/-/arguments-extended-0.0.3.tgz",
       "integrity": "sha1-YQfkkX0OtvCk3WYyD8Fa/HLvSUY=",
       "requires": {
-        "extended": "0.0.6",
-        "is-extended": "0.0.10"
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.8"
       }
     },
     "array-extended": {
@@ -207,9 +222,9 @@
       "resolved": "https://registry.npmjs.org/array-extended/-/array-extended-0.0.11.tgz",
       "integrity": "sha1-1xRK50jek8pybxIQCdv/FibRZL0=",
       "requires": {
-        "arguments-extended": "0.0.3",
-        "extended": "0.0.6",
-        "is-extended": "0.0.10"
+        "arguments-extended": "~0.0.3",
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.3"
       }
     },
     "array-union": {
@@ -218,7 +233,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -251,13 +266,13 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
       "dev": true
     },
     "ast-types": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.3.tgz",
-      "integrity": "sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA==",
+      "integrity": "sha1-wgdX/nLucSeOoP89h+XCyjDZ7fg=",
       "dev": true
     },
     "async": {
@@ -271,8 +286,8 @@
       "integrity": "sha512-E7Z2/QMs0EPt/o9wpYO/J3hmMCDdr1aVDS3ttlur5D5JlZtxhfuOwi4e7S8zbYIxA5qOOYdxfqGj97XAfdNvkQ==",
       "dev": true,
       "requires": {
-        "semver": "5.5.0",
-        "shimmer": "1.2.0"
+        "semver": "^5.3.0",
+        "shimmer": "^1.1.0"
       },
       "dependencies": {
         "semver": {
@@ -291,7 +306,7 @@
     "avsc": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/avsc/-/avsc-5.2.3.tgz",
-      "integrity": "sha512-1qoCOb6Q5q/QmMxmQu5OvKZnv3IELvoz3+rLAhfdslb3JnmtzW3hhLdLJNvpENqCgHzz9tCsdyHMk27m/7wREQ=="
+      "integrity": "sha1-1Sx5iY958DIzX1rjIG/0MAzriBo="
     },
     "aws-sdk": {
       "version": "2.241.1",
@@ -316,6 +331,115 @@
         }
       }
     },
+    "aws-sdk-mock": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-mock/-/aws-sdk-mock-4.1.0.tgz",
+      "integrity": "sha512-JZoLKMzgYXzDdpyKdgw+4JG9nKFd/oab8VDTnwd6iY/mHjmuQUx7kFlOMZ5pNdMK/jcY02Ks7oECHC+ZnwLwqw==",
+      "dev": true,
+      "requires": {
+        "aws-sdk": "^2.260.1",
+        "sinon": "^6.0.0",
+        "traverse": "^0.6.6"
+      },
+      "dependencies": {
+        "aws-sdk": {
+          "version": "2.296.0",
+          "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.296.0.tgz",
+          "integrity": "sha512-Ko76U9N7cr4B4IDUuBqnnH6r+t2WkzydrN0ja8fge+asvuJYavEj/jVq8jjq+yOXfW2KgZ+1uaUDjoV33FAfMQ==",
+          "dev": true,
+          "requires": {
+            "buffer": "4.9.1",
+            "events": "1.1.1",
+            "ieee754": "1.1.8",
+            "jmespath": "0.15.0",
+            "querystring": "0.2.0",
+            "sax": "1.2.1",
+            "url": "0.10.3",
+            "uuid": "3.1.0",
+            "xml2js": "0.4.19"
+          }
+        },
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "lolex": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.1.tgz",
+          "integrity": "sha512-Oo2Si3RMKV3+lV5MsSWplDQFoTClz/24S0MMHYcgGWWmFXr6TMlqcqk/l1GtH+d5wLBwNRiqGnwDRMirtFalJw==",
+          "dev": true
+        },
+        "nise": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.3.tgz",
+          "integrity": "sha512-cg44dkGHutAY+VmftgB1gHvLWxFl2vwYdF8WpbceYicQwylESRJiAAKgCRJntdoEbMiUzywkZEUzjoDWH0JwKA==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/formatio": "^2.0.0",
+            "just-extend": "^1.1.27",
+            "lolex": "^2.3.2",
+            "path-to-regexp": "^1.7.0",
+            "text-encoding": "^0.6.4"
+          }
+        },
+        "sinon": {
+          "version": "6.1.5",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.1.5.tgz",
+          "integrity": "sha512-TcbRoWs1SdY6NOqfj0c9OEQquBoZH+qEf8799m1jjcbfWrrpyCQ3B/BpX7+NKa7Vn33Jl+Z50H4Oys3bzygK2Q==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.0.1",
+            "@sinonjs/formatio": "^2.0.0",
+            "@sinonjs/samsam": "^2.0.0",
+            "diff": "^3.5.0",
+            "lodash.get": "^4.4.2",
+            "lolex": "^2.7.1",
+            "nise": "^1.4.2",
+            "supports-color": "^5.4.0",
+            "type-detect": "^4.0.8"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+          "dev": true
+        },
+        "xml2js": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+          "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+          "dev": true,
+          "requires": {
+            "sax": ">=0.6.0",
+            "xmlbuilder": "~9.0.1"
+          }
+        },
+        "xmlbuilder": {
+          "version": "9.0.7",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+          "dev": true
+        }
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -327,12 +451,12 @@
       "integrity": "sha512-HOSVn0O7ZXKTTgGErpG8GjFfSxhK5vfihqNAPoyi7GYMB16Y25BeWBkfpYVOEWWGYL/9bDcBcRAVc1NJwVJiHQ==",
       "dev": true,
       "requires": {
-        "continuation-local-storage": "3.2.1",
-        "moment": "2.22.1",
-        "pkginfo": "0.4.1",
-        "semver": "5.5.0",
-        "underscore": "1.9.0",
-        "winston": "2.4.2"
+        "continuation-local-storage": "^3.2.0",
+        "moment": "^2.15.2",
+        "pkginfo": "^0.4.0",
+        "semver": "^5.3.0",
+        "underscore": "^1.8.3",
+        "winston": "^2.2.0"
       },
       "dependencies": {
         "semver": {
@@ -365,17 +489,17 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bl": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "integrity": "sha1-oWCRFxcQPAdBDO9j71Gzl8Alr5w=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.2"
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "blessed": {
@@ -388,21 +512,21 @@
       "resolved": "https://registry.npmjs.org/blessed-contrib/-/blessed-contrib-3.5.5.tgz",
       "integrity": "sha1-hbKV4wNjBUeX3NOnv0ek5bvf44w=",
       "requires": {
-        "ansi-term": "0.0.2",
-        "chalk": "1.1.3",
-        "drawille-canvas-blessed-contrib": "0.1.3",
-        "lodash": "4.17.10",
-        "map-canvas": "0.1.5",
-        "marked": "0.3.19",
-        "marked-terminal": "1.7.0",
-        "memory-streams": "0.1.3",
-        "memorystream": "0.3.1",
+        "ansi-term": ">=0.0.2",
+        "chalk": "^1.1.0",
+        "drawille-canvas-blessed-contrib": ">=0.1.3",
+        "lodash": ">=3.0.0",
+        "map-canvas": ">=0.1.5",
+        "marked": "^0.3.3",
+        "marked-terminal": "^1.5.0",
+        "memory-streams": "^0.1.0",
+        "memorystream": "^0.3.1",
         "picture-tube": "0.0.4",
-        "request": "2.86.0",
-        "sparkline": "0.1.2",
-        "strip-ansi": "3.0.1",
+        "request": "^2.53.0",
+        "sparkline": "^0.1.1",
+        "strip-ansi": "^3.0.0",
         "term-canvas": "0.0.5",
-        "x256": "0.0.2"
+        "x256": ">=0.0.1"
       }
     },
     "boom": {
@@ -410,16 +534,16 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -437,16 +561,16 @@
     "bson": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.6.tgz",
-      "integrity": "sha512-D8zmlb46xfuK2gGvKmUjIklQEouN2nQ0LEHHeZ/NoHM2LDiMk2EYzZ5Ntw/Urk+bgMDosOZxaRzXxvhI5TcAVQ=="
+      "integrity": "sha1-RE21nd1MJPDLBjqr3FyMewzsqRI="
     },
     "buffer": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-alloc": {
@@ -455,8 +579,8 @@
       "integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
       "dev": true,
       "requires": {
-        "buffer-alloc-unsafe": "0.1.1",
-        "buffer-fill": "0.1.1"
+        "buffer-alloc-unsafe": "^0.1.0",
+        "buffer-fill": "^0.1.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -480,7 +604,7 @@
     "buffer-from": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
+      "integrity": "sha1-TLiDLSNhJYmwQG6eKVbBfwb99TE="
     },
     "buffer-shims": {
       "version": "1.0.0",
@@ -503,16 +627,16 @@
       "integrity": "sha1-cH/gJv/O3crL/c3zVur9pk8VEEY=",
       "dev": true,
       "requires": {
-        "cssmin": "0.3.2",
-        "jsmin": "1.0.1",
-        "jxLoader": "0.1.1",
-        "moo-server": "1.3.0",
-        "promised-io": "0.3.5",
-        "timespan": "2.3.0",
-        "uglify-js": "1.3.5",
-        "walker": "1.0.7",
-        "winston": "2.4.2",
-        "wrench": "1.3.9"
+        "cssmin": "0.3.x",
+        "jsmin": "1.x",
+        "jxLoader": "*",
+        "moo-server": "*",
+        "promised-io": "*",
+        "timespan": "2.x",
+        "uglify-js": "1.x",
+        "walker": "1.x",
+        "winston": "*",
+        "wrench": "1.3.x"
       }
     },
     "bytes": {
@@ -527,7 +651,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -541,8 +665,8 @@
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
       "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
       "requires": {
-        "ansicolors": "0.2.1",
-        "redeyed": "1.0.1"
+        "ansicolors": "~0.2.1",
+        "redeyed": "~1.0.0"
       }
     },
     "caseless": {
@@ -556,12 +680,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.8"
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       }
     },
     "chalk": {
@@ -569,11 +693,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "charm": {
@@ -590,7 +714,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "cli-cursor": {
@@ -599,7 +723,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^1.0.1"
       }
     },
     "cli-table": {
@@ -642,7 +766,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "command-exists": {
@@ -656,7 +780,7 @@
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
-        "graceful-readlink": "1.0.1"
+        "graceful-readlink": ">= 1.0.0"
       }
     },
     "compress-commons": {
@@ -665,10 +789,10 @@
       "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "0.2.13",
-        "crc32-stream": "2.0.0",
-        "normalize-path": "2.1.1",
-        "readable-stream": "2.3.6"
+        "buffer-crc32": "^0.2.1",
+        "crc32-stream": "^2.0.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
       }
     },
     "concat-map": {
@@ -680,12 +804,12 @@
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "requires": {
-        "buffer-from": "1.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "continuation-local-storage": {
@@ -694,8 +818,8 @@
       "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
       "dev": true,
       "requires": {
-        "async-listener": "0.6.9",
-        "emitter-listener": "1.1.1"
+        "async-listener": "^0.6.0",
+        "emitter-listener": "^1.1.1"
       }
     },
     "core-util-is": {
@@ -715,8 +839,8 @@
       "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
       "dev": true,
       "requires": {
-        "crc": "3.5.0",
-        "readable-stream": "2.3.6"
+        "crc": "^3.4.4",
+        "readable-stream": "^2.0.0"
       }
     },
     "cryptiles": {
@@ -724,15 +848,15 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "requires": {
-            "hoek": "4.2.1"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -754,7 +878,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.42"
+        "es5-ext": "^0.10.9"
       }
     },
     "dashdash": {
@@ -762,13 +886,13 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "data-uri-to-buffer": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
-      "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==",
+      "integrity": "sha1-dxY+qcINhkG0cH6PGKvfmnjzSDU=",
       "dev": true
     },
     "date-extended": {
@@ -776,9 +900,9 @@
       "resolved": "https://registry.npmjs.org/date-extended/-/date-extended-0.0.6.tgz",
       "integrity": "sha1-I4AtV90b94GIE/4MMuhRqG2iZ8k=",
       "requires": {
-        "array-extended": "0.0.11",
-        "extended": "0.0.6",
-        "is-extended": "0.0.10"
+        "array-extended": "~0.0.3",
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.3"
       }
     },
     "debug": {
@@ -804,10 +928,10 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "deep-is": {
@@ -822,7 +946,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "1.0.4"
+        "clone": "^1.0.2"
       },
       "dependencies": {
         "clone": {
@@ -839,9 +963,9 @@
       "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
       "dev": true,
       "requires": {
-        "ast-types": "0.11.3",
-        "escodegen": "1.9.1",
-        "esprima": "3.0.0"
+        "ast-types": "0.x.x",
+        "escodegen": "1.x.x",
+        "esprima": "3.x.x"
       }
     },
     "deglob": {
@@ -850,13 +974,13 @@
       "integrity": "sha1-dtV3wl/j9zKUEqK1nq3qV6xQDj8=",
       "dev": true,
       "requires": {
-        "find-root": "1.1.0",
-        "glob": "7.1.1",
-        "ignore": "3.3.8",
-        "pkg-config": "1.1.1",
-        "run-parallel": "1.1.9",
-        "uniq": "1.0.1",
-        "xtend": "4.0.1"
+        "find-root": "^1.0.0",
+        "glob": "^7.0.5",
+        "ignore": "^3.0.9",
+        "pkg-config": "^1.1.0",
+        "run-parallel": "^1.1.2",
+        "uniq": "^1.0.1",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "ignore": {
@@ -873,13 +997,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "object-assign": "4.1.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "delayed-stream": {
@@ -901,21 +1025,22 @@
     },
     "discovery-store-models": {
       "version": "git+https://github.com/NYPL-discovery/discovery-store-models.git#09653683bbfc9d0c316729b7d3dea328a13d0598",
+      "from": "git+https://github.com/NYPL-discovery/discovery-store-models.git#v1.2.1",
       "requires": {
-        "@nypl/nypl-core-objects": "1.3.1",
-        "pg-promise": "7.5.4",
-        "winston": "2.4.2"
+        "@nypl/nypl-core-objects": "^1.3.1",
+        "pg-promise": "^7.4.0",
+        "winston": "^2.4.0"
       },
       "dependencies": {
         "pg-promise": {
           "version": "7.5.4",
           "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-7.5.4.tgz",
-          "integrity": "sha512-wuL+13P+Ris8MEUpdatv7OH5eHEahWBNmgGHEwLd88fym/eMAjxrFV+3jRKO7bFAyDTvo3wNcmuntYwR9eJnvg==",
+          "integrity": "sha1-we8vka2GhylkmdzPx3CdSzw/pDw=",
           "requires": {
-            "manakin": "0.5.1",
-            "pg": "7.4.3",
-            "pg-minify": "0.5.4",
-            "spex": "2.0.2"
+            "manakin": "~0.5.1",
+            "pg": "~7.4.1",
+            "pg-minify": "~0.5.4",
+            "spex": "~2.0.2"
           }
         }
       }
@@ -926,8 +1051,8 @@
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
       }
     },
     "dotenv": {
@@ -945,11 +1070,11 @@
       "resolved": "https://registry.npmjs.org/drawille-canvas-blessed-contrib/-/drawille-canvas-blessed-contrib-0.1.3.tgz",
       "integrity": "sha1-IS8HinIr/S7MJn6oarbd3BCB/Ug=",
       "requires": {
-        "ansi-term": "0.0.2",
+        "ansi-term": ">=0.0.2",
         "bresenham": "0.0.3",
-        "drawille-blessed-contrib": "1.0.0",
-        "gl-matrix": "2.5.1",
-        "x256": "0.0.2"
+        "drawille-blessed-contrib": ">=0.0.1",
+        "gl-matrix": "^2.1.0",
+        "x256": ">=0.0.1"
       }
     },
     "ecc-jsbn": {
@@ -958,7 +1083,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "elasticsearch": {
@@ -966,12 +1091,12 @@
       "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-13.3.1.tgz",
       "integrity": "sha1-xTCuqa+xfqkcPQpW8fERukm8kjk=",
       "requires": {
-        "agentkeepalive": "2.2.0",
-        "chalk": "1.1.3",
+        "agentkeepalive": "^2.2.0",
+        "chalk": "^1.0.0",
         "lodash": "2.4.2",
-        "lodash.get": "4.4.2",
-        "lodash.isempty": "4.4.0",
-        "lodash.trimend": "4.5.1"
+        "lodash.get": "^4.4.2",
+        "lodash.isempty": "^4.4.0",
+        "lodash.trimend": "^4.5.1"
       },
       "dependencies": {
         "lodash": {
@@ -987,16 +1112,16 @@
       "integrity": "sha1-6Lu+gkS8jg0LTvcc0UKUx/JBx+w=",
       "dev": true,
       "requires": {
-        "shimmer": "1.2.0"
+        "shimmer": "^1.2.0"
       }
     },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "es5-ext": {
@@ -1005,9 +1130,9 @@
       "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1",
-        "next-tick": "1.0.0"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "1"
       }
     },
     "es6-iterator": {
@@ -1016,9 +1141,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-map": {
@@ -1027,12 +1152,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-promise": {
@@ -1046,13 +1171,13 @@
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.2.4"
+        "es6-promise": "^4.0.3"
       },
       "dependencies": {
         "es6-promise": {
           "version": "4.2.4",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
+          "integrity": "sha1-3EIhwrFlGHYL2MOaUtjzVvwA7Sk=",
           "dev": true
         }
       }
@@ -1063,11 +1188,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-iterator": "2.0.3",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-symbol": {
@@ -1076,8 +1201,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "es6-weak-map": {
@@ -1086,10 +1211,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -1100,14 +1225,14 @@
     "escodegen": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
-      "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+      "integrity": "sha1-264X75bI5L7bE1b0UE+kzC98t+I=",
       "dev": true,
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.6.1"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -1124,10 +1249,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint": {
@@ -1136,45 +1261,45 @@
       "integrity": "sha1-bI10OpFUZZW6GG7e0JZoL0dZjeg=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "concat-stream": "1.6.2",
-        "debug": "2.6.8",
-        "doctrine": "1.5.0",
-        "es6-map": "0.1.5",
-        "escope": "3.6.0",
-        "espree": "3.5.4",
-        "estraverse": "4.2.0",
-        "estraverse-fb": "1.3.2",
-        "esutils": "2.0.2",
-        "file-entry-cache": "1.3.1",
-        "glob": "6.0.4",
-        "globals": "8.18.0",
-        "ignore": "2.2.19",
-        "inquirer": "0.12.0",
-        "is-my-json-valid": "2.17.2",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.11.0",
-        "json-stable-stringify": "1.0.1",
-        "lodash": "4.17.10",
-        "mkdirp": "0.5.1",
-        "optionator": "0.8.2",
-        "path-is-absolute": "1.0.1",
-        "path-is-inside": "1.0.2",
-        "pluralize": "1.2.1",
-        "progress": "1.1.8",
-        "require-uncached": "1.0.3",
-        "resolve": "1.7.1",
-        "shelljs": "0.5.3",
-        "strip-json-comments": "1.0.4",
-        "table": "3.8.3",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0"
+        "chalk": "^1.0.0",
+        "concat-stream": "^1.4.6",
+        "debug": "^2.1.1",
+        "doctrine": "^1.1.0",
+        "es6-map": "^0.1.3",
+        "escope": "^3.4.0",
+        "espree": "^3.0.0",
+        "estraverse": "^4.1.1",
+        "estraverse-fb": "^1.3.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^1.1.1",
+        "glob": "^6.0.4",
+        "globals": "^8.18.0",
+        "ignore": "^2.2.19",
+        "inquirer": "^0.12.0",
+        "is-my-json-valid": "^2.10.0",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.5.1",
+        "json-stable-stringify": "^1.0.0",
+        "lodash": "^4.0.0",
+        "mkdirp": "^0.5.0",
+        "optionator": "^0.8.1",
+        "path-is-absolute": "^1.0.0",
+        "path-is-inside": "^1.0.1",
+        "pluralize": "^1.2.1",
+        "progress": "^1.1.8",
+        "require-uncached": "^1.0.2",
+        "resolve": "^1.1.6",
+        "shelljs": "^0.5.3",
+        "strip-json-comments": "~1.0.1",
+        "table": "^3.7.8",
+        "text-table": "~0.2.0",
+        "user-home": "^2.0.0"
       },
       "dependencies": {
         "esprima": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
           "dev": true
         },
         "glob": {
@@ -1183,21 +1308,21 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "js-yaml": {
           "version": "3.11.0",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-          "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+          "integrity": "sha1-WXwai9VxUvJtYizkEXhRpR9euu8=",
           "dev": true,
           "requires": {
-            "argparse": "1.0.10",
-            "esprima": "4.0.0"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         }
       }
@@ -1235,11 +1360,11 @@
     "espree": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
-      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "integrity": "sha1-sPRHGHyKi+2US4FaZgvd9d610ac=",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -1250,10 +1375,10 @@
     "esrecurse": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -1280,8 +1405,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "event-stream": {
@@ -1323,7 +1448,7 @@
       "resolved": "https://registry.npmjs.org/extended/-/extended-0.0.6.tgz",
       "integrity": "sha1-f7i/e52uOXWG5IVwrP1kLHjlBmk=",
       "requires": {
-        "extender": "0.0.10"
+        "extender": "~0.0.5"
       }
     },
     "extender": {
@@ -1331,7 +1456,7 @@
       "resolved": "https://registry.npmjs.org/extender/-/extender-0.0.10.tgz",
       "integrity": "sha1-WJwHSCvmGhRgttgfnCSqZ+jzJM0=",
       "requires": {
-        "declare.js": "0.0.8"
+        "declare.js": "~0.0.4"
       }
     },
     "extsprintf": {
@@ -1377,8 +1502,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.0"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "file-entry-cache": {
@@ -1387,20 +1512,20 @@
       "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.0"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
       "dev": true
     },
     "find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "integrity": "sha1-q8/Iunb3CMQql7PWhbfpRQv7nOQ=",
       "dev": true
     },
     "flat-cache": {
@@ -1409,10 +1534,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "forever-agent": {
@@ -1425,9 +1550,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
     },
     "formatio": {
@@ -1436,7 +1561,7 @@
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "samsam": "1.x"
       }
     },
     "fs-constants": {
@@ -1451,11 +1576,11 @@
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "fs.realpath": {
@@ -1470,7 +1595,7 @@
       "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14",
+        "readable-stream": "1.1.x",
         "xregexp": "2.0.0"
       },
       "dependencies": {
@@ -1486,10 +1611,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -1512,7 +1637,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "generic-pool": {
@@ -1543,12 +1668,12 @@
       "integrity": "sha512-ZD325dMZOgerGqF/rF6vZXyFGTAay62svjQIT+X/oU2PtxYpFxvSkbsdi+oxIrsNxlZVd4y8wUDqkaExWTI/Cw==",
       "dev": true,
       "requires": {
-        "data-uri-to-buffer": "1.2.0",
-        "debug": "2.6.8",
-        "extend": "3.0.1",
-        "file-uri-to-path": "1.0.0",
-        "ftp": "0.3.10",
-        "readable-stream": "2.3.6"
+        "data-uri-to-buffer": "1",
+        "debug": "2",
+        "extend": "3",
+        "file-uri-to-path": "1",
+        "ftp": "~0.3.10",
+        "readable-stream": "2"
       }
     },
     "getpass": {
@@ -1556,7 +1681,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "gl-matrix": {
@@ -1564,7 +1689,7 @@
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-2.5.1.tgz",
       "integrity": "sha512-GCv0L5v+2Hdh+al6Ny7MO4B+BfXd6qfUom6CE5O/nqkBvaIY7+dVZhuKad+EkUK0uyot8V6TkgsMQrQzlmZl2A==",
       "requires": {
-        "npm": "5.10.0"
+        "npm": "^5.8.0"
       }
     },
     "glob": {
@@ -1573,12 +1698,12 @@
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globals": {
@@ -1593,12 +1718,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.1",
-        "object-assign": "4.1.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "graceful-fs": {
@@ -1629,8 +1754,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has-ansi": {
@@ -1638,7 +1763,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -1650,12 +1775,12 @@
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "he": {
@@ -1672,24 +1797,24 @@
     "highland": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/highland/-/highland-2.13.0.tgz",
-      "integrity": "sha512-zGZBcgAHPY2Zf9VG9S5IrlcC7CH9ELioXVtp9T5bU2a4fP2zIsA+Y8pV/n/h2lMwbWMHTX0I0xN0ODJ3Pd3aBQ==",
+      "integrity": "sha1-pDlNjcuXDNBxp5og8HYrkGJY3Bk=",
       "requires": {
-        "util-deprecate": "1.0.2"
+        "util-deprecate": "^1.0.2"
       }
     },
     "hoek": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+      "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs="
     },
     "http-basic": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
       "integrity": "sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=",
       "requires": {
-        "caseless": "0.11.0",
-        "concat-stream": "1.6.2",
-        "http-response-object": "1.1.0"
+        "caseless": "~0.11.0",
+        "concat-stream": "^1.4.6",
+        "http-response-object": "^1.0.0"
       },
       "dependencies": {
         "caseless": {
@@ -1705,10 +1830,10 @@
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.5.0"
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "http-proxy-agent": {
@@ -1717,7 +1842,7 @@
       "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "dev": true,
       "requires": {
-        "agent-base": "4.2.0",
+        "agent-base": "4",
         "debug": "3.1.0"
       },
       "dependencies": {
@@ -1742,9 +1867,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -1753,8 +1878,8 @@
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
       "requires": {
-        "agent-base": "4.2.0",
-        "debug": "3.1.0"
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -1774,7 +1899,7 @@
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ieee754": {
@@ -1794,8 +1919,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1809,19 +1934,19 @@
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.2.0",
-        "figures": "1.7.0",
-        "lodash": "4.17.10",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
       }
     },
     "ip": {
@@ -1835,7 +1960,7 @@
       "resolved": "https://registry.npmjs.org/is-extended/-/is-extended-0.0.10.tgz",
       "integrity": "sha1-JE4UDfdbscmjEG9BL/GC+1NKbWI=",
       "requires": {
-        "extended": "0.0.6"
+        "extended": "~0.0.3"
       }
     },
     "is-fullwidth-code-point": {
@@ -1844,26 +1969,26 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-my-ip-valid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "integrity": "sha1-ezUbjo7dTTmV1NBmaA5mTZRpaCQ=",
       "dev": true
     },
     "is-my-json-valid": {
       "version": "2.17.2",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+      "integrity": "sha1-ayEDoojpTvPeXPFdKd2F/Et41lw=",
       "dev": true,
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-path-cwd": {
@@ -1875,10 +2000,10 @@
     "is-path-in-cwd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "integrity": "sha1-WsSLNF72dTOb1sekipEhELJBz1I=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -1887,7 +2012,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-property": {
@@ -1899,7 +2024,7 @@
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
       "dev": true
     },
     "is-typedarray": {
@@ -1961,7 +2086,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -1981,7 +2106,7 @@
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -1995,9 +2120,9 @@
       "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-0.4.12.tgz",
       "integrity": "sha1-oC8gXVNBQU3xtthBTxuWenEgc+g=",
       "requires": {
-        "es6-promise": "2.3.0",
-        "pkginfo": "0.4.1",
-        "request": "2.86.0",
+        "es6-promise": "^2.0.0",
+        "pkginfo": "~0.4.0",
+        "request": "^2.61.0",
         "xmldom": "0.1.19"
       }
     },
@@ -2026,7 +2151,7 @@
     "just-extend": {
       "version": "1.1.27",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "integrity": "sha1-7G55QQ/5FORyZSq/oOYDwD1g6QU=",
       "dev": true
     },
     "just-flatten": {
@@ -2040,10 +2165,10 @@
       "integrity": "sha1-ATTqUUTlM7WU/B/yX/GU4jXFPs0=",
       "dev": true,
       "requires": {
-        "js-yaml": "0.3.7",
-        "moo-server": "1.3.0",
-        "promised-io": "0.3.5",
-        "walker": "1.0.7"
+        "js-yaml": "0.3.x",
+        "moo-server": "1.3.x",
+        "promised-io": "*",
+        "walker": "1.x"
       }
     },
     "klaw": {
@@ -2052,7 +2177,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "lazystream": {
@@ -2061,7 +2186,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.5"
       }
     },
     "levn": {
@@ -2070,8 +2195,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lodash": {
@@ -2085,8 +2210,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -2124,9 +2249,9 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.get": {
@@ -2157,9 +2282,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.toarray": {
@@ -2189,8 +2314,8 @@
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "makeerror": {
@@ -2199,7 +2324,7 @@
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
-        "tmpl": "1.0.4"
+        "tmpl": "1.0.x"
       }
     },
     "manakin": {
@@ -2212,33 +2337,33 @@
       "resolved": "https://registry.npmjs.org/map-canvas/-/map-canvas-0.1.5.tgz",
       "integrity": "sha1-i+a63gvz6fmotW6INqHR0TPKsYY=",
       "requires": {
-        "drawille-canvas-blessed-contrib": "0.1.3",
-        "xml2js": "0.4.17"
+        "drawille-canvas-blessed-contrib": ">=0.0.1",
+        "xml2js": "^0.4.5"
       }
     },
     "marked": {
       "version": "0.3.19",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
+      "integrity": "sha1-XUf3CcTJ/Dwha21GEnKA9As515A="
     },
     "marked-terminal": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.7.0.tgz",
       "integrity": "sha1-yMRgiBx3LHYEtkNnAH7l938SWQQ=",
       "requires": {
-        "cardinal": "1.0.0",
-        "chalk": "1.1.3",
-        "cli-table": "0.3.1",
-        "lodash.assign": "4.2.0",
-        "node-emoji": "1.8.1"
+        "cardinal": "^1.0.0",
+        "chalk": "^1.1.3",
+        "cli-table": "^0.3.1",
+        "lodash.assign": "^4.2.0",
+        "node-emoji": "^1.4.1"
       }
     },
     "memory-streams": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.3.tgz",
-      "integrity": "sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==",
+      "integrity": "sha1-2bABe0uH8dkvVfJ0XJyqyx3JPOs=",
       "requires": {
-        "readable-stream": "1.0.34"
+        "readable-stream": "~1.0.2"
       },
       "dependencies": {
         "isarray": {
@@ -2251,10 +2376,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -2272,23 +2397,23 @@
     "mime-db": {
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+      "integrity": "sha1-o0kgUKXLm2NFBUHjnZeI0icng9s="
     },
     "mime-types": {
       "version": "2.1.18",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "integrity": "sha1-bzI/YKg9ERRvgx/xH9ZuL+VQO7g=",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -2316,7 +2441,7 @@
     "mocha": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -2339,7 +2464,7 @@
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -2353,7 +2478,7 @@
     "mongodb": {
       "version": "2.2.35",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.35.tgz",
-      "integrity": "sha512-3HGLucDg/8EeYMin3k+nFWChTA85hcYDCw1lPsWR6yV9A6RgKb24BkLiZ9ySZR+S0nfBjWoIUS7cyV6ceGx5Gg==",
+      "integrity": "sha1-zRta+KlGPj+aeH+ls9BVZVeXMPk=",
       "requires": {
         "es6-promise": "3.2.1",
         "mongodb-core": "2.1.19",
@@ -2375,13 +2500,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
           "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
           "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -2389,7 +2514,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -2397,10 +2522,10 @@
     "mongodb-core": {
       "version": "2.1.19",
       "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.19.tgz",
-      "integrity": "sha512-Jt4AtWUkpuW03kRdYGxga4O65O1UHlFfvvInslEfLlGi+zDMxbBe3J2NVmN9qPJ957Mn6Iz0UpMtV80cmxCVxw==",
+      "integrity": "sha1-APvV5aNXN2O5Fxz9hE5gqPKjoYs=",
       "requires": {
-        "bson": "1.0.6",
-        "require_optional": "1.0.1"
+        "bson": "~1.0.4",
+        "require_optional": "~1.0.0"
       }
     },
     "moo-server": {
@@ -2421,7 +2546,7 @@
       "integrity": "sha1-abHyX/B00oKJBPJE3dBrfZbvbJM=",
       "dev": true,
       "requires": {
-        "strip-indent": "1.0.1"
+        "strip-indent": "^1.0.0"
       }
     },
     "mute-stream": {
@@ -2454,28 +2579,28 @@
       "integrity": "sha512-v1J/FLUB9PfGqZLGDBhQqODkbLotP0WtLo9R4EJY2PPu5f5Xg4o0rA8FDlmrjFSv9vBBKcfnOSpfYYuu5RTHqg==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "2.0.0",
-        "just-extend": "1.1.27",
-        "lolex": "2.6.0",
-        "path-to-regexp": "1.7.0",
-        "text-encoding": "0.6.4"
+        "@sinonjs/formatio": "^2.0.0",
+        "just-extend": "^1.1.27",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
       }
     },
     "node-cache": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.0.tgz",
-      "integrity": "sha512-obRu6/f7S024ysheAjoYFEEBqqDWv4LOMNJEuO8vMeEw2AT4z+NCzO4hlc2lhI4vATzbCQv6kke9FVdx0RbCOw==",
+      "integrity": "sha1-SKx5aodOdiWCaSAEo3bSbfqHWBE=",
       "requires": {
-        "clone": "2.1.1",
-        "lodash": "4.17.10"
+        "clone": "2.x",
+        "lodash": "4.x"
       }
     },
     "node-emoji": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
-      "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
+      "integrity": "sha1-buxr+wdCHiFIx1xrunJCH4UwqCY=",
       "requires": {
-        "lodash.toarray": "4.4.0"
+        "lodash.toarray": "^4.4.0"
       }
     },
     "node-lambda": {
@@ -2484,15 +2609,15 @@
       "integrity": "sha512-1qvfYWJyLLVB3PxDSlEHVoTT4JsBdSkrFmCdpvbH0ghxd+EwssPkxATIO2hVvhAzDCSnaCxg0lSxZd8oG6xSVw==",
       "dev": true,
       "requires": {
-        "archiver": "2.1.1",
-        "aws-sdk": "2.241.1",
-        "aws-xray-sdk-core": "1.2.0",
-        "commander": "2.15.1",
-        "continuation-local-storage": "3.2.1",
-        "dotenv": "0.4.0",
-        "fs-extra": "0.30.0",
-        "minimatch": "3.0.4",
-        "proxy-agent": "2.3.1"
+        "archiver": "^2.1.1",
+        "aws-sdk": "^2.203.0",
+        "aws-xray-sdk-core": "^1.2.0",
+        "commander": "^2.14.1",
+        "continuation-local-storage": "^3.2.1",
+        "dotenv": "^0.4.0",
+        "fs-extra": "^0.30.0",
+        "minimatch": "^3.0.3",
+        "proxy-agent": "^2.2.0"
       },
       "dependencies": {
         "commander": {
@@ -2514,7 +2639,7 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
       "integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1"
       }
     },
     "normalize-path": {
@@ -2523,7 +2648,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "npm": {
@@ -2531,130 +2656,130 @@
       "resolved": "https://registry.npmjs.org/npm/-/npm-5.10.0.tgz",
       "integrity": "sha512-lvjvjgR5wG2RJ2uqak1xtZcVAWMwVOzN5HkUlUj/n8rU1f3A0fNn+7HwOzH9Lyf0Ppyu9ApgsEpHczOSnx1cwA==",
       "requires": {
-        "JSONStream": "1.3.2",
-        "abbrev": "1.1.1",
-        "ansi-regex": "3.0.0",
-        "ansicolors": "0.3.2",
-        "ansistyles": "0.1.3",
-        "aproba": "1.2.0",
-        "archy": "1.0.0",
-        "bin-links": "1.1.0",
-        "bluebird": "3.5.1",
-        "byte-size": "4.0.2",
-        "cacache": "10.0.4",
-        "call-limit": "1.1.0",
-        "chownr": "1.0.1",
-        "cli-columns": "3.1.2",
-        "cli-table2": "0.2.0",
-        "cmd-shim": "2.0.2",
-        "columnify": "1.5.4",
-        "config-chain": "1.1.11",
-        "debuglog": "1.0.1",
-        "detect-indent": "5.0.0",
-        "detect-newline": "2.1.0",
-        "dezalgo": "1.0.3",
-        "editor": "1.0.0",
-        "find-npm-prefix": "1.0.2",
-        "fs-vacuum": "1.2.10",
-        "fs-write-stream-atomic": "1.0.10",
-        "gentle-fs": "2.0.1",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "has-unicode": "2.0.1",
-        "hosted-git-info": "2.6.0",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "ini": "1.3.5",
-        "init-package-json": "1.10.3",
-        "is-cidr": "1.0.0",
-        "json-parse-better-errors": "1.0.2",
-        "lazy-property": "1.0.0",
-        "libcipm": "1.6.2",
-        "libnpx": "10.2.0",
-        "lock-verify": "2.0.2",
-        "lockfile": "1.0.4",
-        "lodash._baseindexof": "3.1.0",
-        "lodash._baseuniq": "4.6.0",
-        "lodash._bindcallback": "3.0.1",
-        "lodash._cacheindexof": "3.0.2",
-        "lodash._createcache": "3.1.2",
-        "lodash._getnative": "3.9.1",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.restparam": "3.6.1",
-        "lodash.union": "4.6.0",
-        "lodash.uniq": "4.5.0",
-        "lodash.without": "4.4.0",
-        "lru-cache": "4.1.2",
-        "meant": "1.0.1",
-        "mississippi": "3.0.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "node-gyp": "3.6.2",
-        "nopt": "4.0.1",
-        "normalize-package-data": "2.4.0",
-        "npm-audit-report": "1.0.9",
-        "npm-cache-filename": "1.0.2",
-        "npm-install-checks": "3.0.0",
-        "npm-lifecycle": "2.0.1",
-        "npm-package-arg": "6.1.0",
-        "npm-packlist": "1.1.10",
-        "npm-profile": "3.0.1",
-        "npm-registry-client": "8.5.1",
-        "npm-registry-fetch": "1.1.0",
-        "npm-user-validate": "1.0.0",
-        "npmlog": "4.1.2",
-        "once": "1.4.0",
-        "opener": "1.4.3",
-        "osenv": "0.1.5",
-        "pacote": "7.6.1",
-        "path-is-inside": "1.0.2",
-        "promise-inflight": "1.0.1",
-        "qrcode-terminal": "0.12.0",
-        "query-string": "6.1.0",
-        "qw": "1.0.1",
-        "read": "1.0.7",
-        "read-cmd-shim": "1.0.1",
-        "read-installed": "4.0.3",
-        "read-package-json": "2.0.13",
-        "read-package-tree": "5.2.1",
-        "readable-stream": "2.3.6",
-        "readdir-scoped-modules": "1.0.2",
-        "request": "2.85.0",
-        "retry": "0.12.0",
-        "rimraf": "2.6.2",
-        "safe-buffer": "5.1.2",
-        "semver": "5.5.0",
-        "sha": "2.0.1",
-        "slide": "1.1.6",
-        "sorted-object": "2.0.1",
-        "sorted-union-stream": "2.1.3",
-        "ssri": "5.3.0",
-        "strip-ansi": "4.0.0",
-        "tar": "4.4.2",
-        "text-table": "0.2.0",
-        "tiny-relative-date": "1.3.0",
+        "JSONStream": "^1.3.2",
+        "abbrev": "~1.1.1",
+        "ansi-regex": "~3.0.0",
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "aproba": "~1.2.0",
+        "archy": "~1.0.0",
+        "bin-links": "^1.1.0",
+        "bluebird": "~3.5.1",
+        "byte-size": "^4.0.2",
+        "cacache": "^10.0.4",
+        "call-limit": "~1.1.0",
+        "chownr": "~1.0.1",
+        "cli-columns": "^3.1.2",
+        "cli-table2": "~0.2.0",
+        "cmd-shim": "~2.0.2",
+        "columnify": "~1.5.4",
+        "config-chain": "~1.1.11",
+        "debuglog": "*",
+        "detect-indent": "~5.0.0",
+        "detect-newline": "^2.1.0",
+        "dezalgo": "~1.0.3",
+        "editor": "~1.0.0",
+        "find-npm-prefix": "^1.0.2",
+        "fs-vacuum": "~1.2.10",
+        "fs-write-stream-atomic": "~1.0.10",
+        "gentle-fs": "^2.0.1",
+        "glob": "~7.1.2",
+        "graceful-fs": "~4.1.11",
+        "has-unicode": "~2.0.1",
+        "hosted-git-info": "^2.6.0",
+        "iferr": "~0.1.5",
+        "imurmurhash": "*",
+        "inflight": "~1.0.6",
+        "inherits": "~2.0.3",
+        "ini": "^1.3.5",
+        "init-package-json": "^1.10.3",
+        "is-cidr": "~1.0.0",
+        "json-parse-better-errors": "^1.0.2",
+        "lazy-property": "~1.0.0",
+        "libcipm": "^1.6.2",
+        "libnpx": "^10.2.0",
+        "lock-verify": "^2.0.2",
+        "lockfile": "^1.0.4",
+        "lodash._baseindexof": "*",
+        "lodash._baseuniq": "~4.6.0",
+        "lodash._bindcallback": "*",
+        "lodash._cacheindexof": "*",
+        "lodash._createcache": "*",
+        "lodash._getnative": "*",
+        "lodash.clonedeep": "~4.5.0",
+        "lodash.restparam": "*",
+        "lodash.union": "~4.6.0",
+        "lodash.uniq": "~4.5.0",
+        "lodash.without": "~4.4.0",
+        "lru-cache": "^4.1.2",
+        "meant": "~1.0.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "~0.5.1",
+        "move-concurrently": "^1.0.1",
+        "node-gyp": "^3.6.2",
+        "nopt": "~4.0.1",
+        "normalize-package-data": "~2.4.0",
+        "npm-audit-report": "^1.0.9",
+        "npm-cache-filename": "~1.0.2",
+        "npm-install-checks": "~3.0.0",
+        "npm-lifecycle": "^2.0.1",
+        "npm-package-arg": "^6.1.0",
+        "npm-packlist": "~1.1.10",
+        "npm-profile": "^3.0.1",
+        "npm-registry-client": "^8.5.1",
+        "npm-registry-fetch": "^1.1.0",
+        "npm-user-validate": "~1.0.0",
+        "npmlog": "~4.1.2",
+        "once": "~1.4.0",
+        "opener": "~1.4.3",
+        "osenv": "^0.1.5",
+        "pacote": "^7.6.1",
+        "path-is-inside": "~1.0.2",
+        "promise-inflight": "~1.0.1",
+        "qrcode-terminal": "^0.12.0",
+        "query-string": "^6.1.0",
+        "qw": "~1.0.1",
+        "read": "~1.0.7",
+        "read-cmd-shim": "~1.0.1",
+        "read-installed": "~4.0.3",
+        "read-package-json": "^2.0.13",
+        "read-package-tree": "^5.2.1",
+        "readable-stream": "^2.3.6",
+        "readdir-scoped-modules": "*",
+        "request": "^2.85.0",
+        "retry": "^0.12.0",
+        "rimraf": "~2.6.2",
+        "safe-buffer": "^5.1.2",
+        "semver": "^5.5.0",
+        "sha": "~2.0.1",
+        "slide": "~1.1.6",
+        "sorted-object": "~2.0.1",
+        "sorted-union-stream": "~2.1.3",
+        "ssri": "^5.3.0",
+        "strip-ansi": "~4.0.0",
+        "tar": "^4.4.2",
+        "text-table": "~0.2.0",
+        "tiny-relative-date": "^1.3.0",
         "uid-number": "0.0.6",
-        "umask": "1.1.0",
-        "unique-filename": "1.1.0",
-        "unpipe": "1.0.0",
-        "update-notifier": "2.5.0",
-        "uuid": "3.2.1",
-        "validate-npm-package-license": "3.0.3",
-        "validate-npm-package-name": "3.0.0",
-        "which": "1.3.0",
-        "worker-farm": "1.6.0",
-        "wrappy": "1.0.2",
-        "write-file-atomic": "2.3.0"
+        "umask": "~1.1.0",
+        "unique-filename": "~1.1.0",
+        "unpipe": "~1.0.0",
+        "update-notifier": "^2.5.0",
+        "uuid": "^3.2.1",
+        "validate-npm-package-license": "^3.0.3",
+        "validate-npm-package-name": "~3.0.0",
+        "which": "~1.3.0",
+        "worker-farm": "^1.6.0",
+        "wrappy": "~1.0.2",
+        "write-file-atomic": "^2.3.0"
       },
       "dependencies": {
         "JSONStream": {
           "version": "1.3.2",
           "bundled": true,
           "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
           },
           "dependencies": {
             "jsonparse": {
@@ -2695,12 +2820,12 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "cmd-shim": "2.0.2",
-            "fs-write-stream-atomic": "1.0.10",
-            "gentle-fs": "2.0.1",
-            "graceful-fs": "4.1.11",
-            "slide": "1.1.6"
+            "bluebird": "^3.5.0",
+            "cmd-shim": "^2.0.2",
+            "fs-write-stream-atomic": "^1.0.10",
+            "gentle-fs": "^2.0.0",
+            "graceful-fs": "^4.1.11",
+            "slide": "^1.1.6"
           }
         },
         "bluebird": {
@@ -2715,44 +2840,44 @@
           "version": "10.0.4",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "chownr": "1.0.1",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "lru-cache": "4.1.2",
-            "mississippi": "2.0.0",
-            "mkdirp": "0.5.1",
-            "move-concurrently": "1.0.1",
-            "promise-inflight": "1.0.1",
-            "rimraf": "2.6.2",
-            "ssri": "5.3.0",
-            "unique-filename": "1.1.0",
-            "y18n": "4.0.0"
+            "bluebird": "^3.5.1",
+            "chownr": "^1.0.1",
+            "glob": "^7.1.2",
+            "graceful-fs": "^4.1.11",
+            "lru-cache": "^4.1.1",
+            "mississippi": "^2.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "ssri": "^5.2.4",
+            "unique-filename": "^1.1.0",
+            "y18n": "^4.0.0"
           },
           "dependencies": {
             "mississippi": {
               "version": "2.0.0",
               "bundled": true,
               "requires": {
-                "concat-stream": "1.6.1",
-                "duplexify": "3.5.4",
-                "end-of-stream": "1.4.1",
-                "flush-write-stream": "1.0.2",
-                "from2": "2.3.0",
-                "parallel-transform": "1.1.0",
-                "pump": "2.0.1",
-                "pumpify": "1.4.0",
-                "stream-each": "1.2.2",
-                "through2": "2.0.3"
+                "concat-stream": "^1.5.0",
+                "duplexify": "^3.4.2",
+                "end-of-stream": "^1.1.0",
+                "flush-write-stream": "^1.0.0",
+                "from2": "^2.1.0",
+                "parallel-transform": "^1.1.0",
+                "pump": "^2.0.1",
+                "pumpify": "^1.3.3",
+                "stream-each": "^1.1.0",
+                "through2": "^2.0.0"
               },
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.1",
                   "bundled": true,
                   "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.6",
-                    "typedarray": "0.0.6"
+                    "inherits": "^2.0.3",
+                    "readable-stream": "^2.2.2",
+                    "typedarray": "^0.0.6"
                   },
                   "dependencies": {
                     "typedarray": {
@@ -2765,10 +2890,10 @@
                   "version": "3.5.4",
                   "bundled": true,
                   "requires": {
-                    "end-of-stream": "1.4.1",
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.6",
-                    "stream-shift": "1.0.0"
+                    "end-of-stream": "^1.0.0",
+                    "inherits": "^2.0.1",
+                    "readable-stream": "^2.0.0",
+                    "stream-shift": "^1.0.0"
                   },
                   "dependencies": {
                     "stream-shift": {
@@ -2781,32 +2906,32 @@
                   "version": "1.4.1",
                   "bundled": true,
                   "requires": {
-                    "once": "1.4.0"
+                    "once": "^1.4.0"
                   }
                 },
                 "flush-write-stream": {
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.6"
+                    "inherits": "^2.0.1",
+                    "readable-stream": "^2.0.4"
                   }
                 },
                 "from2": {
                   "version": "2.3.0",
                   "bundled": true,
                   "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.6"
+                    "inherits": "^2.0.1",
+                    "readable-stream": "^2.0.0"
                   }
                 },
                 "parallel-transform": {
                   "version": "1.1.0",
                   "bundled": true,
                   "requires": {
-                    "cyclist": "0.2.2",
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.6"
+                    "cyclist": "~0.2.2",
+                    "inherits": "^2.0.3",
+                    "readable-stream": "^2.1.5"
                   },
                   "dependencies": {
                     "cyclist": {
@@ -2819,25 +2944,25 @@
                   "version": "2.0.1",
                   "bundled": true,
                   "requires": {
-                    "end-of-stream": "1.4.1",
-                    "once": "1.4.0"
+                    "end-of-stream": "^1.1.0",
+                    "once": "^1.3.1"
                   }
                 },
                 "pumpify": {
                   "version": "1.4.0",
                   "bundled": true,
                   "requires": {
-                    "duplexify": "3.5.4",
-                    "inherits": "2.0.3",
-                    "pump": "2.0.1"
+                    "duplexify": "^3.5.3",
+                    "inherits": "^2.0.3",
+                    "pump": "^2.0.0"
                   }
                 },
                 "stream-each": {
                   "version": "1.2.2",
                   "bundled": true,
                   "requires": {
-                    "end-of-stream": "1.4.1",
-                    "stream-shift": "1.0.0"
+                    "end-of-stream": "^1.1.0",
+                    "stream-shift": "^1.0.0"
                   },
                   "dependencies": {
                     "stream-shift": {
@@ -2850,8 +2975,8 @@
                   "version": "2.0.3",
                   "bundled": true,
                   "requires": {
-                    "readable-stream": "2.3.6",
-                    "xtend": "4.0.1"
+                    "readable-stream": "^2.1.5",
+                    "xtend": "~4.0.1"
                   },
                   "dependencies": {
                     "xtend": {
@@ -2880,16 +3005,16 @@
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "3.0.1"
+            "string-width": "^2.0.0",
+            "strip-ansi": "^3.0.1"
           },
           "dependencies": {
             "string-width": {
               "version": "2.1.1",
               "bundled": true,
               "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
               },
               "dependencies": {
                 "is-fullwidth-code-point": {
@@ -2900,7 +3025,7 @@
                   "version": "4.0.0",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "3.0.0"
+                    "ansi-regex": "^3.0.0"
                   }
                 }
               }
@@ -2909,7 +3034,7 @@
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -2924,9 +3049,9 @@
           "version": "0.2.0",
           "bundled": true,
           "requires": {
-            "colors": "1.1.2",
-            "lodash": "3.10.1",
-            "string-width": "1.0.2"
+            "colors": "^1.1.2",
+            "lodash": "^3.10.1",
+            "string-width": "^1.0.1"
           },
           "dependencies": {
             "colors": {
@@ -2942,9 +3067,9 @@
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               },
               "dependencies": {
                 "code-point-at": {
@@ -2955,7 +3080,7 @@
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "number-is-nan": "1.0.1"
+                    "number-is-nan": "^1.0.0"
                   },
                   "dependencies": {
                     "number-is-nan": {
@@ -2968,7 +3093,7 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "2.1.1"
+                    "ansi-regex": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -2985,23 +3110,23 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1"
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "~0.5.0"
           }
         },
         "columnify": {
           "version": "1.5.4",
           "bundled": true,
           "requires": {
-            "strip-ansi": "3.0.1",
-            "wcwidth": "1.0.1"
+            "strip-ansi": "^3.0.0",
+            "wcwidth": "^1.0.0"
           },
           "dependencies": {
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -3014,14 +3139,14 @@
               "version": "1.0.1",
               "bundled": true,
               "requires": {
-                "defaults": "1.0.3"
+                "defaults": "^1.0.3"
               },
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
                   "bundled": true,
                   "requires": {
-                    "clone": "1.0.2"
+                    "clone": "^1.0.2"
                   },
                   "dependencies": {
                     "clone": {
@@ -3038,8 +3163,8 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "ini": "1.3.5",
-            "proto-list": "1.2.4"
+            "ini": "^1.3.4",
+            "proto-list": "~1.2.1"
           },
           "dependencies": {
             "proto-list": {
@@ -3064,8 +3189,8 @@
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "asap": "2.0.5",
-            "wrappy": "1.0.2"
+            "asap": "^2.0.0",
+            "wrappy": "1"
           },
           "dependencies": {
             "asap": {
@@ -3086,45 +3211,45 @@
           "version": "1.2.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "path-is-inside": "1.0.2",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "path-is-inside": "^1.0.1",
+            "rimraf": "^2.5.2"
           }
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "iferr": "0.1.5",
-            "imurmurhash": "0.1.4",
-            "readable-stream": "2.3.6"
+            "graceful-fs": "^4.1.2",
+            "iferr": "^0.1.5",
+            "imurmurhash": "^0.1.4",
+            "readable-stream": "1 || 2"
           }
         },
         "gentle-fs": {
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "fs-vacuum": "1.2.10",
-            "graceful-fs": "4.1.11",
-            "iferr": "0.1.5",
-            "mkdirp": "0.5.1",
-            "path-is-inside": "1.0.2",
-            "read-cmd-shim": "1.0.1",
-            "slide": "1.1.6"
+            "aproba": "^1.1.2",
+            "fs-vacuum": "^1.2.10",
+            "graceful-fs": "^4.1.11",
+            "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
+            "path-is-inside": "^1.0.2",
+            "read-cmd-shim": "^1.0.1",
+            "slide": "^1.1.6"
           }
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           },
           "dependencies": {
             "fs.realpath": {
@@ -3135,14 +3260,14 @@
               "version": "3.0.4",
               "bundled": true,
               "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
                   "bundled": true,
                   "requires": {
-                    "balanced-match": "1.0.0",
+                    "balanced-match": "^1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -3188,8 +3313,8 @@
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -3204,21 +3329,21 @@
           "version": "1.10.3",
           "bundled": true,
           "requires": {
-            "glob": "7.1.2",
-            "npm-package-arg": "6.1.0",
-            "promzard": "0.3.0",
-            "read": "1.0.7",
-            "read-package-json": "2.0.13",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.3",
-            "validate-npm-package-name": "3.0.0"
+            "glob": "^7.1.1",
+            "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+            "promzard": "^0.3.0",
+            "read": "~1.0.1",
+            "read-package-json": "1 || 2",
+            "semver": "2.x || 3.x || 4 || 5",
+            "validate-npm-package-license": "^3.0.1",
+            "validate-npm-package-name": "^3.0.0"
           },
           "dependencies": {
             "promzard": {
               "version": "0.3.0",
               "bundled": true,
               "requires": {
-                "read": "1.0.7"
+                "read": "1"
               }
             }
           }
@@ -3248,37 +3373,37 @@
           "version": "1.6.2",
           "bundled": true,
           "requires": {
-            "bin-links": "1.1.0",
-            "bluebird": "3.5.1",
-            "find-npm-prefix": "1.0.2",
-            "graceful-fs": "4.1.11",
-            "lock-verify": "2.0.1",
-            "npm-lifecycle": "2.0.1",
-            "npm-logical-tree": "1.2.1",
-            "npm-package-arg": "6.1.0",
-            "pacote": "7.6.1",
-            "protoduck": "5.0.0",
-            "read-package-json": "2.0.13",
-            "rimraf": "2.6.2",
-            "worker-farm": "1.6.0"
+            "bin-links": "^1.1.0",
+            "bluebird": "^3.5.1",
+            "find-npm-prefix": "^1.0.2",
+            "graceful-fs": "^4.1.11",
+            "lock-verify": "^2.0.0",
+            "npm-lifecycle": "^2.0.0",
+            "npm-logical-tree": "^1.2.1",
+            "npm-package-arg": "^6.0.0",
+            "pacote": "^7.5.1",
+            "protoduck": "^5.0.0",
+            "read-package-json": "^2.0.12",
+            "rimraf": "^2.6.2",
+            "worker-farm": "^1.5.4"
           },
           "dependencies": {
             "lock-verify": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "npm-package-arg": "5.1.2",
-                "semver": "5.5.0"
+                "npm-package-arg": "^5.1.2",
+                "semver": "^5.4.1"
               },
               "dependencies": {
                 "npm-package-arg": {
                   "version": "5.1.2",
                   "bundled": true,
                   "requires": {
-                    "hosted-git-info": "2.6.0",
-                    "osenv": "0.1.5",
-                    "semver": "5.5.0",
-                    "validate-npm-package-name": "3.0.0"
+                    "hosted-git-info": "^2.4.2",
+                    "osenv": "^0.1.4",
+                    "semver": "^5.1.0",
+                    "validate-npm-package-name": "^3.0.0"
                   }
                 }
               }
@@ -3291,7 +3416,7 @@
               "version": "5.0.0",
               "bundled": true,
               "requires": {
-                "genfun": "4.0.1"
+                "genfun": "^4.0.1"
               },
               "dependencies": {
                 "genfun": {
@@ -3306,14 +3431,14 @@
           "version": "10.2.0",
           "bundled": true,
           "requires": {
-            "dotenv": "5.0.1",
-            "npm-package-arg": "6.1.0",
-            "rimraf": "2.6.2",
-            "safe-buffer": "5.1.2",
-            "update-notifier": "2.5.0",
-            "which": "1.3.0",
-            "y18n": "4.0.0",
-            "yargs": "11.0.0"
+            "dotenv": "^5.0.1",
+            "npm-package-arg": "^6.0.0",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.0",
+            "update-notifier": "^2.3.0",
+            "which": "^1.3.0",
+            "y18n": "^4.0.0",
+            "yargs": "^11.0.0"
           },
           "dependencies": {
             "dotenv": {
@@ -3328,44 +3453,44 @@
               "version": "11.0.0",
               "bundled": true,
               "requires": {
-                "cliui": "4.1.0",
-                "decamelize": "1.2.0",
-                "find-up": "2.1.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "2.1.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.1",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "9.0.2"
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^9.0.2"
               },
               "dependencies": {
                 "cliui": {
                   "version": "4.1.0",
                   "bundled": true,
                   "requires": {
-                    "string-width": "2.1.1",
-                    "strip-ansi": "4.0.0",
-                    "wrap-ansi": "2.1.0"
+                    "string-width": "^2.1.1",
+                    "strip-ansi": "^4.0.0",
+                    "wrap-ansi": "^2.0.0"
                   },
                   "dependencies": {
                     "wrap-ansi": {
                       "version": "2.1.0",
                       "bundled": true,
                       "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1"
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1"
                       },
                       "dependencies": {
                         "string-width": {
                           "version": "1.0.2",
                           "bundled": true,
                           "requires": {
-                            "code-point-at": "1.1.0",
-                            "is-fullwidth-code-point": "1.0.0",
-                            "strip-ansi": "3.0.1"
+                            "code-point-at": "^1.0.0",
+                            "is-fullwidth-code-point": "^1.0.0",
+                            "strip-ansi": "^3.0.0"
                           },
                           "dependencies": {
                             "code-point-at": {
@@ -3376,7 +3501,7 @@
                               "version": "1.0.0",
                               "bundled": true,
                               "requires": {
-                                "number-is-nan": "1.0.1"
+                                "number-is-nan": "^1.0.0"
                               },
                               "dependencies": {
                                 "number-is-nan": {
@@ -3391,7 +3516,7 @@
                           "version": "3.0.1",
                           "bundled": true,
                           "requires": {
-                            "ansi-regex": "2.1.1"
+                            "ansi-regex": "^2.0.0"
                           },
                           "dependencies": {
                             "ansi-regex": {
@@ -3412,29 +3537,29 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "locate-path": "2.0.0"
+                    "locate-path": "^2.0.0"
                   },
                   "dependencies": {
                     "locate-path": {
                       "version": "2.0.0",
                       "bundled": true,
                       "requires": {
-                        "p-locate": "2.0.0",
-                        "path-exists": "3.0.0"
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
                       },
                       "dependencies": {
                         "p-locate": {
                           "version": "2.0.0",
                           "bundled": true,
                           "requires": {
-                            "p-limit": "1.2.0"
+                            "p-limit": "^1.1.0"
                           },
                           "dependencies": {
                             "p-limit": {
                               "version": "1.2.0",
                               "bundled": true,
                               "requires": {
-                                "p-try": "1.0.0"
+                                "p-try": "^1.0.0"
                               },
                               "dependencies": {
                                 "p-try": {
@@ -3461,38 +3586,38 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "execa": "0.7.0",
-                    "lcid": "1.0.0",
-                    "mem": "1.1.0"
+                    "execa": "^0.7.0",
+                    "lcid": "^1.0.0",
+                    "mem": "^1.1.0"
                   },
                   "dependencies": {
                     "execa": {
                       "version": "0.7.0",
                       "bundled": true,
                       "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                       },
                       "dependencies": {
                         "cross-spawn": {
                           "version": "5.1.0",
                           "bundled": true,
                           "requires": {
-                            "lru-cache": "4.1.2",
-                            "shebang-command": "1.2.0",
-                            "which": "1.3.0"
+                            "lru-cache": "^4.0.1",
+                            "shebang-command": "^1.2.0",
+                            "which": "^1.2.9"
                           },
                           "dependencies": {
                             "shebang-command": {
                               "version": "1.2.0",
                               "bundled": true,
                               "requires": {
-                                "shebang-regex": "1.0.0"
+                                "shebang-regex": "^1.0.0"
                               },
                               "dependencies": {
                                 "shebang-regex": {
@@ -3515,7 +3640,7 @@
                           "version": "2.0.2",
                           "bundled": true,
                           "requires": {
-                            "path-key": "2.0.1"
+                            "path-key": "^2.0.0"
                           },
                           "dependencies": {
                             "path-key": {
@@ -3542,7 +3667,7 @@
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "invert-kv": "1.0.0"
+                        "invert-kv": "^1.0.0"
                       },
                       "dependencies": {
                         "invert-kv": {
@@ -3555,7 +3680,7 @@
                       "version": "1.1.0",
                       "bundled": true,
                       "requires": {
-                        "mimic-fn": "1.2.0"
+                        "mimic-fn": "^1.0.0"
                       },
                       "dependencies": {
                         "mimic-fn": {
@@ -3582,8 +3707,8 @@
                   "version": "2.1.1",
                   "bundled": true,
                   "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "4.0.0"
+                    "is-fullwidth-code-point": "^2.0.0",
+                    "strip-ansi": "^4.0.0"
                   },
                   "dependencies": {
                     "is-fullwidth-code-point": {
@@ -3604,7 +3729,7 @@
                   "version": "9.0.2",
                   "bundled": true,
                   "requires": {
-                    "camelcase": "4.1.0"
+                    "camelcase": "^4.1.0"
                   },
                   "dependencies": {
                     "camelcase": {
@@ -3621,15 +3746,15 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "6.1.0",
-            "semver": "5.5.0"
+            "npm-package-arg": "^5.1.2 || 6",
+            "semver": "^5.4.1"
           }
         },
         "lockfile": {
           "version": "1.0.4",
           "bundled": true,
           "requires": {
-            "signal-exit": "3.0.2"
+            "signal-exit": "^3.0.2"
           },
           "dependencies": {
             "signal-exit": {
@@ -3646,8 +3771,8 @@
           "version": "4.6.0",
           "bundled": true,
           "requires": {
-            "lodash._createset": "4.0.3",
-            "lodash._root": "3.0.1"
+            "lodash._createset": "~4.0.0",
+            "lodash._root": "~3.0.0"
           },
           "dependencies": {
             "lodash._createset": {
@@ -3672,7 +3797,7 @@
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "lodash._getnative": "3.9.1"
+            "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._getnative": {
@@ -3703,8 +3828,8 @@
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           },
           "dependencies": {
             "pseudomap": {
@@ -3725,25 +3850,25 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "concat-stream": "1.6.1",
-            "duplexify": "3.5.4",
-            "end-of-stream": "1.4.1",
-            "flush-write-stream": "1.0.2",
-            "from2": "2.3.0",
-            "parallel-transform": "1.1.0",
-            "pump": "3.0.0",
-            "pumpify": "1.4.0",
-            "stream-each": "1.2.2",
-            "through2": "2.0.3"
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
           },
           "dependencies": {
             "concat-stream": {
               "version": "1.6.1",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
               },
               "dependencies": {
                 "typedarray": {
@@ -3756,10 +3881,10 @@
               "version": "3.5.4",
               "bundled": true,
               "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -3772,32 +3897,32 @@
               "version": "1.4.1",
               "bundled": true,
               "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
               }
             },
             "flush-write-stream": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.4"
               }
             },
             "from2": {
               "version": "2.3.0",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0"
               }
             },
             "parallel-transform": {
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "cyclist": "0.2.2",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "cyclist": "~0.2.2",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.1.5"
               },
               "dependencies": {
                 "cyclist": {
@@ -3810,25 +3935,25 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
               }
             },
             "pumpify": {
               "version": "1.4.0",
               "bundled": true,
               "requires": {
-                "duplexify": "3.5.4",
-                "inherits": "2.0.3",
-                "pump": "2.0.1"
+                "duplexify": "^3.5.3",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
               },
               "dependencies": {
                 "pump": {
                   "version": "2.0.1",
                   "bundled": true,
                   "requires": {
-                    "end-of-stream": "1.4.1",
-                    "once": "1.4.0"
+                    "end-of-stream": "^1.1.0",
+                    "once": "^1.3.1"
                   }
                 }
               }
@@ -3837,8 +3962,8 @@
               "version": "1.2.2",
               "bundled": true,
               "requires": {
-                "end-of-stream": "1.4.1",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.1.0",
+                "stream-shift": "^1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -3851,8 +3976,8 @@
               "version": "2.0.3",
               "bundled": true,
               "requires": {
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
               },
               "dependencies": {
                 "xtend": {
@@ -3880,31 +4005,31 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "copy-concurrently": "1.0.5",
-            "fs-write-stream-atomic": "1.0.10",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "run-queue": "1.0.3"
+            "aproba": "^1.1.1",
+            "copy-concurrently": "^1.0.0",
+            "fs-write-stream-atomic": "^1.0.8",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.3"
           },
           "dependencies": {
             "copy-concurrently": {
               "version": "1.0.5",
               "bundled": true,
               "requires": {
-                "aproba": "1.2.0",
-                "fs-write-stream-atomic": "1.0.10",
-                "iferr": "0.1.5",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "run-queue": "1.0.3"
+                "aproba": "^1.1.1",
+                "fs-write-stream-atomic": "^1.0.8",
+                "iferr": "^0.1.5",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.0"
               }
             },
             "run-queue": {
               "version": "1.0.3",
               "bundled": true,
               "requires": {
-                "aproba": "1.2.0"
+                "aproba": "^1.1.1"
               }
             }
           }
@@ -3913,43 +4038,43 @@
           "version": "3.6.2",
           "bundled": true,
           "requires": {
-            "fstream": "1.0.11",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "npmlog": "4.1.2",
-            "osenv": "0.1.5",
-            "request": "2.85.0",
-            "rimraf": "2.6.2",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "which": "1.3.0"
+            "fstream": "^1.0.0",
+            "glob": "^7.0.3",
+            "graceful-fs": "^4.1.2",
+            "minimatch": "^3.0.2",
+            "mkdirp": "^0.5.0",
+            "nopt": "2 || 3",
+            "npmlog": "0 || 1 || 2 || 3 || 4",
+            "osenv": "0",
+            "request": "2",
+            "rimraf": "2",
+            "semver": "~5.3.0",
+            "tar": "^2.0.0",
+            "which": "1"
           },
           "dependencies": {
             "fstream": {
               "version": "1.0.11",
               "bundled": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
               }
             },
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
               "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.11",
                   "bundled": true,
                   "requires": {
-                    "balanced-match": "1.0.0",
+                    "balanced-match": "^1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -3969,7 +4094,7 @@
               "version": "3.0.6",
               "bundled": true,
               "requires": {
-                "abbrev": "1.1.1"
+                "abbrev": "1"
               }
             },
             "semver": {
@@ -3980,16 +4105,16 @@
               "version": "2.2.1",
               "bundled": true,
               "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
               },
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
                   "bundled": true,
                   "requires": {
-                    "inherits": "2.0.3"
+                    "inherits": "~2.0.0"
                   }
                 }
               }
@@ -4000,25 +4125,25 @@
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.6.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.3"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           },
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
               },
               "dependencies": {
                 "builtin-modules": {
@@ -4033,8 +4158,8 @@
           "version": "1.0.9",
           "bundled": true,
           "requires": {
-            "cli-table2": "0.2.0",
-            "console-control-strings": "1.1.0"
+            "cli-table2": "^0.2.0",
+            "console-control-strings": "^1.1.0"
           },
           "dependencies": {
             "console-control-strings": {
@@ -4051,21 +4176,21 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "semver": "5.5.0"
+            "semver": "^2.3.0 || 3.x || 4 || 5"
           }
         },
         "npm-lifecycle": {
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "byline": "5.0.0",
-            "graceful-fs": "4.1.11",
-            "node-gyp": "3.6.2",
-            "resolve-from": "4.0.0",
-            "slide": "1.1.6",
+            "byline": "^5.0.0",
+            "graceful-fs": "^4.1.11",
+            "node-gyp": "^3.6.2",
+            "resolve-from": "^4.0.0",
+            "slide": "^1.1.6",
             "uid-number": "0.0.6",
-            "umask": "1.1.0",
-            "which": "1.3.0"
+            "umask": "^1.1.0",
+            "which": "^1.3.0"
           },
           "dependencies": {
             "byline": {
@@ -4082,39 +4207,39 @@
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.6.0",
-            "osenv": "0.1.5",
-            "semver": "5.5.0",
-            "validate-npm-package-name": "3.0.0"
+            "hosted-git-info": "^2.6.0",
+            "osenv": "^0.1.5",
+            "semver": "^5.5.0",
+            "validate-npm-package-name": "^3.0.0"
           }
         },
         "npm-packlist": {
           "version": "1.1.10",
           "bundled": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           },
           "dependencies": {
             "ignore-walk": {
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "minimatch": "3.0.4"
+                "minimatch": "^3.0.4"
               },
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
                   "bundled": true,
                   "requires": {
-                    "brace-expansion": "1.1.8"
+                    "brace-expansion": "^1.1.7"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
                       "bundled": true,
                       "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -4142,39 +4267,39 @@
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "make-fetch-happen": "2.6.0"
+            "aproba": "^1.1.2",
+            "make-fetch-happen": "^2.5.0"
           },
           "dependencies": {
             "make-fetch-happen": {
               "version": "2.6.0",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "3.3.0",
-                "cacache": "10.0.4",
-                "http-cache-semantics": "3.8.1",
-                "http-proxy-agent": "2.0.0",
-                "https-proxy-agent": "2.1.1",
-                "lru-cache": "4.1.2",
-                "mississippi": "1.3.1",
-                "node-fetch-npm": "2.0.2",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.1",
-                "ssri": "5.3.0"
+                "agentkeepalive": "^3.3.0",
+                "cacache": "^10.0.0",
+                "http-cache-semantics": "^3.8.0",
+                "http-proxy-agent": "^2.0.0",
+                "https-proxy-agent": "^2.1.0",
+                "lru-cache": "^4.1.1",
+                "mississippi": "^1.2.0",
+                "node-fetch-npm": "^2.0.2",
+                "promise-retry": "^1.1.1",
+                "socks-proxy-agent": "^3.0.1",
+                "ssri": "^5.0.0"
               },
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.3.0",
                   "bundled": true,
                   "requires": {
-                    "humanize-ms": "1.2.1"
+                    "humanize-ms": "^1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
                       "requires": {
-                        "ms": "2.1.1"
+                        "ms": "^2.0.0"
                       },
                       "dependencies": {
                         "ms": {
@@ -4193,22 +4318,22 @@
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "2.6.9"
+                    "agent-base": "4",
+                    "debug": "2"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -4238,22 +4363,22 @@
                   "version": "2.1.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "3.1.0"
+                    "agent-base": "^4.1.0",
+                    "debug": "^3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -4283,25 +4408,25 @@
                   "version": "1.3.1",
                   "bundled": true,
                   "requires": {
-                    "concat-stream": "1.6.0",
-                    "duplexify": "3.5.3",
-                    "end-of-stream": "1.4.1",
-                    "flush-write-stream": "1.0.2",
-                    "from2": "2.3.0",
-                    "parallel-transform": "1.1.0",
-                    "pump": "1.0.3",
-                    "pumpify": "1.4.0",
-                    "stream-each": "1.2.2",
-                    "through2": "2.0.3"
+                    "concat-stream": "^1.5.0",
+                    "duplexify": "^3.4.2",
+                    "end-of-stream": "^1.1.0",
+                    "flush-write-stream": "^1.0.0",
+                    "from2": "^2.1.0",
+                    "parallel-transform": "^1.1.0",
+                    "pump": "^1.0.0",
+                    "pumpify": "^1.3.3",
+                    "stream-each": "^1.1.0",
+                    "through2": "^2.0.0"
                   },
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.6.0",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6",
-                        "typedarray": "0.0.6"
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.2.2",
+                        "typedarray": "^0.0.6"
                       },
                       "dependencies": {
                         "typedarray": {
@@ -4314,10 +4439,10 @@
                       "version": "3.5.3",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6",
-                        "stream-shift": "1.0.0"
+                        "end-of-stream": "^1.0.0",
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0",
+                        "stream-shift": "^1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -4330,32 +4455,32 @@
                       "version": "1.4.1",
                       "bundled": true,
                       "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                       }
                     },
                     "flush-write-stream": {
                       "version": "1.0.2",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.4"
                       }
                     },
                     "from2": {
                       "version": "2.3.0",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0"
                       }
                     },
                     "parallel-transform": {
                       "version": "1.1.0",
                       "bundled": true,
                       "requires": {
-                        "cyclist": "0.2.2",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "cyclist": "~0.2.2",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.1.5"
                       },
                       "dependencies": {
                         "cyclist": {
@@ -4368,25 +4493,25 @@
                       "version": "1.0.3",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "once": "1.4.0"
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
                       }
                     },
                     "pumpify": {
                       "version": "1.4.0",
                       "bundled": true,
                       "requires": {
-                        "duplexify": "3.5.3",
-                        "inherits": "2.0.3",
-                        "pump": "2.0.1"
+                        "duplexify": "^3.5.3",
+                        "inherits": "^2.0.3",
+                        "pump": "^2.0.0"
                       },
                       "dependencies": {
                         "pump": {
                           "version": "2.0.1",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "1.4.1",
-                            "once": "1.4.0"
+                            "end-of-stream": "^1.1.0",
+                            "once": "^1.3.1"
                           }
                         }
                       }
@@ -4395,8 +4520,8 @@
                       "version": "1.2.2",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "stream-shift": "1.0.0"
+                        "end-of-stream": "^1.1.0",
+                        "stream-shift": "^1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -4409,8 +4534,8 @@
                       "version": "2.0.3",
                       "bundled": true,
                       "requires": {
-                        "readable-stream": "2.3.6",
-                        "xtend": "4.0.1"
+                        "readable-stream": "^2.1.5",
+                        "xtend": "~4.0.1"
                       },
                       "dependencies": {
                         "xtend": {
@@ -4425,16 +4550,16 @@
                   "version": "2.0.2",
                   "bundled": true,
                   "requires": {
-                    "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.1",
-                    "safe-buffer": "5.1.2"
+                    "encoding": "^0.1.11",
+                    "json-parse-better-errors": "^1.0.0",
+                    "safe-buffer": "^5.1.1"
                   },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
                       "requires": {
-                        "iconv-lite": "0.4.19"
+                        "iconv-lite": "~0.4.13"
                       },
                       "dependencies": {
                         "iconv-lite": {
@@ -4453,8 +4578,8 @@
                   "version": "1.1.1",
                   "bundled": true,
                   "requires": {
-                    "err-code": "1.1.2",
-                    "retry": "0.10.1"
+                    "err-code": "^1.0.0",
+                    "retry": "^0.10.0"
                   },
                   "dependencies": {
                     "err-code": {
@@ -4471,22 +4596,22 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "socks": "1.1.10"
+                    "agent-base": "^4.1.0",
+                    "socks": "^1.1.10"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -4501,8 +4626,8 @@
                       "version": "1.1.10",
                       "bundled": true,
                       "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "1.1.15"
+                        "ip": "^1.1.4",
+                        "smart-buffer": "^1.0.13"
                       },
                       "dependencies": {
                         "ip": {
@@ -4525,27 +4650,27 @@
           "version": "8.5.1",
           "bundled": true,
           "requires": {
-            "concat-stream": "1.6.1",
-            "graceful-fs": "4.1.11",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "6.1.0",
-            "npmlog": "4.1.2",
-            "once": "1.4.0",
-            "request": "2.85.0",
-            "retry": "0.10.1",
-            "safe-buffer": "5.1.2",
-            "semver": "5.5.0",
-            "slide": "1.1.6",
-            "ssri": "5.3.0"
+            "concat-stream": "^1.5.2",
+            "graceful-fs": "^4.1.6",
+            "normalize-package-data": "~1.0.1 || ^2.0.0",
+            "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+            "npmlog": "2 || ^3.1.0 || ^4.0.0",
+            "once": "^1.3.3",
+            "request": "^2.74.0",
+            "retry": "^0.10.0",
+            "safe-buffer": "^5.1.1",
+            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
+            "slide": "^1.1.3",
+            "ssri": "^5.2.4"
           },
           "dependencies": {
             "concat-stream": {
               "version": "1.6.1",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
               },
               "dependencies": {
                 "typedarray": {
@@ -4564,12 +4689,12 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "figgy-pudding": "2.0.1",
-            "lru-cache": "4.1.2",
-            "make-fetch-happen": "3.0.0",
-            "npm-package-arg": "6.1.0",
-            "safe-buffer": "5.1.2"
+            "bluebird": "^3.5.1",
+            "figgy-pudding": "^2.0.1",
+            "lru-cache": "^4.1.2",
+            "make-fetch-happen": "^3.0.0",
+            "npm-package-arg": "^6.0.0",
+            "safe-buffer": "^5.1.1"
           },
           "dependencies": {
             "figgy-pudding": {
@@ -4580,31 +4705,31 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "3.4.1",
-                "cacache": "10.0.4",
-                "http-cache-semantics": "3.8.1",
-                "http-proxy-agent": "2.1.0",
-                "https-proxy-agent": "2.2.1",
-                "lru-cache": "4.1.2",
-                "mississippi": "3.0.0",
-                "node-fetch-npm": "2.0.2",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.1",
-                "ssri": "5.3.0"
+                "agentkeepalive": "^3.4.1",
+                "cacache": "^10.0.4",
+                "http-cache-semantics": "^3.8.1",
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.0",
+                "lru-cache": "^4.1.2",
+                "mississippi": "^3.0.0",
+                "node-fetch-npm": "^2.0.2",
+                "promise-retry": "^1.1.1",
+                "socks-proxy-agent": "^3.0.1",
+                "ssri": "^5.2.4"
               },
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.4.1",
                   "bundled": true,
                   "requires": {
-                    "humanize-ms": "1.2.1"
+                    "humanize-ms": "^1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
                       "requires": {
-                        "ms": "2.1.1"
+                        "ms": "^2.0.0"
                       },
                       "dependencies": {
                         "ms": {
@@ -4623,7 +4748,7 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
+                    "agent-base": "4",
                     "debug": "3.1.0"
                   },
                   "dependencies": {
@@ -4631,14 +4756,14 @@
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -4668,22 +4793,22 @@
                   "version": "2.2.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "3.1.0"
+                    "agent-base": "^4.1.0",
+                    "debug": "^3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -4713,23 +4838,23 @@
                   "version": "2.0.2",
                   "bundled": true,
                   "requires": {
-                    "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.2",
-                    "safe-buffer": "5.1.2"
+                    "encoding": "^0.1.11",
+                    "json-parse-better-errors": "^1.0.0",
+                    "safe-buffer": "^5.1.1"
                   },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
                       "requires": {
-                        "iconv-lite": "0.4.21"
+                        "iconv-lite": "~0.4.13"
                       },
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.21",
                           "bundled": true,
                           "requires": {
-                            "safer-buffer": "2.1.2"
+                            "safer-buffer": "^2.1.0"
                           },
                           "dependencies": {
                             "safer-buffer": {
@@ -4746,8 +4871,8 @@
                   "version": "1.1.1",
                   "bundled": true,
                   "requires": {
-                    "err-code": "1.1.2",
-                    "retry": "0.10.1"
+                    "err-code": "^1.0.0",
+                    "retry": "^0.10.0"
                   },
                   "dependencies": {
                     "err-code": {
@@ -4764,22 +4889,22 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "socks": "1.1.10"
+                    "agent-base": "^4.1.0",
+                    "socks": "^1.1.10"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -4794,8 +4919,8 @@
                       "version": "1.1.10",
                       "bundled": true,
                       "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "1.1.15"
+                        "ip": "^1.1.4",
+                        "smart-buffer": "^1.0.13"
                       },
                       "dependencies": {
                         "ip": {
@@ -4822,18 +4947,18 @@
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           },
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.1.4",
               "bundled": true,
               "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.6"
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
               },
               "dependencies": {
                 "delegates": {
@@ -4850,14 +4975,14 @@
               "version": "2.7.4",
               "bundled": true,
               "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
               },
               "dependencies": {
                 "object-assign": {
@@ -4872,9 +4997,9 @@
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
                   },
                   "dependencies": {
                     "code-point-at": {
@@ -4885,7 +5010,7 @@
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                       },
                       "dependencies": {
                         "number-is-nan": {
@@ -4900,7 +5025,7 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "2.1.1"
+                    "ansi-regex": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -4913,7 +5038,7 @@
                   "version": "1.1.2",
                   "bundled": true,
                   "requires": {
-                    "string-width": "1.0.2"
+                    "string-width": "^1.0.2"
                   }
                 }
               }
@@ -4928,7 +5053,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "opener": {
@@ -4939,8 +5064,8 @@
           "version": "0.1.5",
           "bundled": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           },
           "dependencies": {
             "os-homedir": {
@@ -4957,30 +5082,30 @@
           "version": "7.6.1",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "cacache": "10.0.4",
-            "get-stream": "3.0.0",
-            "glob": "7.1.2",
-            "lru-cache": "4.1.2",
-            "make-fetch-happen": "2.6.0",
-            "minimatch": "3.0.4",
-            "mississippi": "3.0.0",
-            "mkdirp": "0.5.1",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "6.1.0",
-            "npm-packlist": "1.1.10",
-            "npm-pick-manifest": "2.1.0",
-            "osenv": "0.1.5",
-            "promise-inflight": "1.0.1",
-            "promise-retry": "1.1.1",
-            "protoduck": "5.0.0",
-            "rimraf": "2.6.2",
-            "safe-buffer": "5.1.2",
-            "semver": "5.5.0",
-            "ssri": "5.3.0",
-            "tar": "4.4.2",
-            "unique-filename": "1.1.0",
-            "which": "1.3.0"
+            "bluebird": "^3.5.1",
+            "cacache": "^10.0.4",
+            "get-stream": "^3.0.0",
+            "glob": "^7.1.2",
+            "lru-cache": "^4.1.1",
+            "make-fetch-happen": "^2.6.0",
+            "minimatch": "^3.0.4",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "normalize-package-data": "^2.4.0",
+            "npm-package-arg": "^6.0.0",
+            "npm-packlist": "^1.1.10",
+            "npm-pick-manifest": "^2.1.0",
+            "osenv": "^0.1.5",
+            "promise-inflight": "^1.0.1",
+            "promise-retry": "^1.1.1",
+            "protoduck": "^5.0.0",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.1",
+            "semver": "^5.5.0",
+            "ssri": "^5.2.4",
+            "tar": "^4.4.0",
+            "unique-filename": "^1.1.0",
+            "which": "^1.3.0"
           },
           "dependencies": {
             "get-stream": {
@@ -4991,31 +5116,31 @@
               "version": "2.6.0",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "3.4.0",
-                "cacache": "10.0.4",
-                "http-cache-semantics": "3.8.1",
-                "http-proxy-agent": "2.1.0",
-                "https-proxy-agent": "2.2.0",
-                "lru-cache": "4.1.2",
-                "mississippi": "1.3.1",
-                "node-fetch-npm": "2.0.2",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.1",
-                "ssri": "5.3.0"
+                "agentkeepalive": "^3.3.0",
+                "cacache": "^10.0.0",
+                "http-cache-semantics": "^3.8.0",
+                "http-proxy-agent": "^2.0.0",
+                "https-proxy-agent": "^2.1.0",
+                "lru-cache": "^4.1.1",
+                "mississippi": "^1.2.0",
+                "node-fetch-npm": "^2.0.2",
+                "promise-retry": "^1.1.1",
+                "socks-proxy-agent": "^3.0.1",
+                "ssri": "^5.0.0"
               },
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.4.0",
                   "bundled": true,
                   "requires": {
-                    "humanize-ms": "1.2.1"
+                    "humanize-ms": "^1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
                       "requires": {
-                        "ms": "2.1.1"
+                        "ms": "^2.0.0"
                       },
                       "dependencies": {
                         "ms": {
@@ -5034,7 +5159,7 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
+                    "agent-base": "4",
                     "debug": "3.1.0"
                   },
                   "dependencies": {
@@ -5042,14 +5167,14 @@
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -5079,22 +5204,22 @@
                   "version": "2.2.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "3.1.0"
+                    "agent-base": "^4.1.0",
+                    "debug": "^3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -5124,25 +5249,25 @@
                   "version": "1.3.1",
                   "bundled": true,
                   "requires": {
-                    "concat-stream": "1.6.1",
-                    "duplexify": "3.5.4",
-                    "end-of-stream": "1.4.1",
-                    "flush-write-stream": "1.0.2",
-                    "from2": "2.3.0",
-                    "parallel-transform": "1.1.0",
-                    "pump": "1.0.3",
-                    "pumpify": "1.4.0",
-                    "stream-each": "1.2.2",
-                    "through2": "2.0.3"
+                    "concat-stream": "^1.5.0",
+                    "duplexify": "^3.4.2",
+                    "end-of-stream": "^1.1.0",
+                    "flush-write-stream": "^1.0.0",
+                    "from2": "^2.1.0",
+                    "parallel-transform": "^1.1.0",
+                    "pump": "^1.0.0",
+                    "pumpify": "^1.3.3",
+                    "stream-each": "^1.1.0",
+                    "through2": "^2.0.0"
                   },
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.6.1",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6",
-                        "typedarray": "0.0.6"
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.2.2",
+                        "typedarray": "^0.0.6"
                       },
                       "dependencies": {
                         "typedarray": {
@@ -5155,10 +5280,10 @@
                       "version": "3.5.4",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6",
-                        "stream-shift": "1.0.0"
+                        "end-of-stream": "^1.0.0",
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0",
+                        "stream-shift": "^1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -5171,32 +5296,32 @@
                       "version": "1.4.1",
                       "bundled": true,
                       "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                       }
                     },
                     "flush-write-stream": {
                       "version": "1.0.2",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.4"
                       }
                     },
                     "from2": {
                       "version": "2.3.0",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0"
                       }
                     },
                     "parallel-transform": {
                       "version": "1.1.0",
                       "bundled": true,
                       "requires": {
-                        "cyclist": "0.2.2",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "cyclist": "~0.2.2",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.1.5"
                       },
                       "dependencies": {
                         "cyclist": {
@@ -5209,25 +5334,25 @@
                       "version": "1.0.3",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "once": "1.4.0"
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
                       }
                     },
                     "pumpify": {
                       "version": "1.4.0",
                       "bundled": true,
                       "requires": {
-                        "duplexify": "3.5.4",
-                        "inherits": "2.0.3",
-                        "pump": "2.0.1"
+                        "duplexify": "^3.5.3",
+                        "inherits": "^2.0.3",
+                        "pump": "^2.0.0"
                       },
                       "dependencies": {
                         "pump": {
                           "version": "2.0.1",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "1.4.1",
-                            "once": "1.4.0"
+                            "end-of-stream": "^1.1.0",
+                            "once": "^1.3.1"
                           }
                         }
                       }
@@ -5236,8 +5361,8 @@
                       "version": "1.2.2",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "stream-shift": "1.0.0"
+                        "end-of-stream": "^1.1.0",
+                        "stream-shift": "^1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -5250,8 +5375,8 @@
                       "version": "2.0.3",
                       "bundled": true,
                       "requires": {
-                        "readable-stream": "2.3.6",
-                        "xtend": "4.0.1"
+                        "readable-stream": "^2.1.5",
+                        "xtend": "~4.0.1"
                       },
                       "dependencies": {
                         "xtend": {
@@ -5266,16 +5391,16 @@
                   "version": "2.0.2",
                   "bundled": true,
                   "requires": {
-                    "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.1",
-                    "safe-buffer": "5.1.2"
+                    "encoding": "^0.1.11",
+                    "json-parse-better-errors": "^1.0.0",
+                    "safe-buffer": "^5.1.1"
                   },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
                       "requires": {
-                        "iconv-lite": "0.4.19"
+                        "iconv-lite": "~0.4.13"
                       },
                       "dependencies": {
                         "iconv-lite": {
@@ -5294,22 +5419,22 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "socks": "1.1.10"
+                    "agent-base": "^4.1.0",
+                    "socks": "^1.1.10"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -5324,8 +5449,8 @@
                       "version": "1.1.10",
                       "bundled": true,
                       "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "1.1.15"
+                        "ip": "^1.1.4",
+                        "smart-buffer": "^1.0.13"
                       },
                       "dependencies": {
                         "ip": {
@@ -5346,14 +5471,14 @@
               "version": "3.0.4",
               "bundled": true,
               "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.11",
                   "bundled": true,
                   "requires": {
-                    "balanced-match": "1.0.0",
+                    "balanced-match": "^1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -5373,16 +5498,16 @@
               "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "npm-package-arg": "6.1.0",
-                "semver": "5.5.0"
+                "npm-package-arg": "^6.0.0",
+                "semver": "^5.4.1"
               }
             },
             "promise-retry": {
               "version": "1.1.1",
               "bundled": true,
               "requires": {
-                "err-code": "1.1.2",
-                "retry": "0.10.1"
+                "err-code": "^1.0.0",
+                "retry": "^0.10.0"
               },
               "dependencies": {
                 "err-code": {
@@ -5399,7 +5524,7 @@
               "version": "5.0.0",
               "bundled": true,
               "requires": {
-                "genfun": "4.0.1"
+                "genfun": "^4.0.1"
               },
               "dependencies": {
                 "genfun": {
@@ -5426,8 +5551,8 @@
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "decode-uri-component": "0.2.0",
-            "strict-uri-encode": "2.0.0"
+            "decode-uri-component": "^0.2.0",
+            "strict-uri-encode": "^2.0.0"
           },
           "dependencies": {
             "decode-uri-component": {
@@ -5448,7 +5573,7 @@
           "version": "1.0.7",
           "bundled": true,
           "requires": {
-            "mute-stream": "0.0.7"
+            "mute-stream": "~0.0.4"
           },
           "dependencies": {
             "mute-stream": {
@@ -5461,20 +5586,20 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.2"
           }
         },
         "read-installed": {
           "version": "4.0.3",
           "bundled": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "graceful-fs": "4.1.11",
-            "read-package-json": "2.0.13",
-            "readdir-scoped-modules": "1.0.2",
-            "semver": "5.5.0",
-            "slide": "1.1.6",
-            "util-extend": "1.0.3"
+            "debuglog": "^1.0.1",
+            "graceful-fs": "^4.1.2",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "slide": "~1.1.3",
+            "util-extend": "^1.0.1"
           },
           "dependencies": {
             "util-extend": {
@@ -5487,11 +5612,11 @@
           "version": "2.0.13",
           "bundled": true,
           "requires": {
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "json-parse-better-errors": "1.0.1",
-            "normalize-package-data": "2.4.0",
-            "slash": "1.0.0"
+            "glob": "^7.1.1",
+            "graceful-fs": "^4.1.2",
+            "json-parse-better-errors": "^1.0.1",
+            "normalize-package-data": "^2.0.0",
+            "slash": "^1.0.0"
           },
           "dependencies": {
             "json-parse-better-errors": {
@@ -5508,24 +5633,24 @@
           "version": "5.2.1",
           "bundled": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "once": "1.4.0",
-            "read-package-json": "2.0.13",
-            "readdir-scoped-modules": "1.0.2"
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "once": "^1.3.0",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0"
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           },
           "dependencies": {
             "core-util-is": {
@@ -5544,7 +5669,7 @@
               "version": "1.1.1",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
               }
             },
             "util-deprecate": {
@@ -5557,38 +5682,38 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "graceful-fs": "4.1.11",
-            "once": "1.4.0"
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "graceful-fs": "^4.1.2",
+            "once": "^1.3.0"
           }
         },
         "request": {
           "version": "2.85.0",
           "bundled": true,
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "hawk": "~6.0.2",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "stringstream": "~0.0.5",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
           },
           "dependencies": {
             "aws-sign2": {
@@ -5607,7 +5732,7 @@
               "version": "1.0.6",
               "bundled": true,
               "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
               },
               "dependencies": {
                 "delayed-stream": {
@@ -5628,9 +5753,9 @@
               "version": "2.3.2",
               "bundled": true,
               "requires": {
-                "asynckit": "0.4.0",
+                "asynckit": "^0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
+                "mime-types": "^2.1.12"
               },
               "dependencies": {
                 "asynckit": {
@@ -5643,18 +5768,18 @@
               "version": "5.0.3",
               "bundled": true,
               "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
+                "ajv": "^5.1.0",
+                "har-schema": "^2.0.0"
               },
               "dependencies": {
                 "ajv": {
                   "version": "5.5.2",
                   "bundled": true,
                   "requires": {
-                    "co": "4.6.0",
-                    "fast-deep-equal": "1.1.0",
-                    "fast-json-stable-stringify": "2.0.0",
-                    "json-schema-traverse": "0.3.1"
+                    "co": "^4.6.0",
+                    "fast-deep-equal": "^1.0.0",
+                    "fast-json-stable-stringify": "^2.0.0",
+                    "json-schema-traverse": "^0.3.0"
                   },
                   "dependencies": {
                     "co": {
@@ -5685,31 +5810,31 @@
               "version": "6.0.2",
               "bundled": true,
               "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.1",
-                "sntp": "2.1.0"
+                "boom": "4.x.x",
+                "cryptiles": "3.x.x",
+                "hoek": "4.x.x",
+                "sntp": "2.x.x"
               },
               "dependencies": {
                 "boom": {
                   "version": "4.3.1",
                   "bundled": true,
                   "requires": {
-                    "hoek": "4.2.1"
+                    "hoek": "4.x.x"
                   }
                 },
                 "cryptiles": {
                   "version": "3.1.2",
                   "bundled": true,
                   "requires": {
-                    "boom": "5.2.0"
+                    "boom": "5.x.x"
                   },
                   "dependencies": {
                     "boom": {
                       "version": "5.2.0",
                       "bundled": true,
                       "requires": {
-                        "hoek": "4.2.1"
+                        "hoek": "4.x.x"
                       }
                     }
                   }
@@ -5722,7 +5847,7 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "hoek": "4.2.1"
+                    "hoek": "4.x.x"
                   }
                 }
               }
@@ -5731,9 +5856,9 @@
               "version": "1.2.0",
               "bundled": true,
               "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.1"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -5762,9 +5887,9 @@
                       "version": "1.10.0",
                       "bundled": true,
                       "requires": {
-                        "assert-plus": "1.0.0",
+                        "assert-plus": "^1.0.0",
                         "core-util-is": "1.0.2",
-                        "extsprintf": "1.3.0"
+                        "extsprintf": "^1.2.0"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -5779,14 +5904,14 @@
                   "version": "1.14.1",
                   "bundled": true,
                   "requires": {
-                    "asn1": "0.2.3",
-                    "assert-plus": "1.0.0",
-                    "bcrypt-pbkdf": "1.0.1",
-                    "dashdash": "1.14.1",
-                    "ecc-jsbn": "0.1.1",
-                    "getpass": "0.1.7",
-                    "jsbn": "0.1.1",
-                    "tweetnacl": "0.14.5"
+                    "asn1": "~0.2.3",
+                    "assert-plus": "^1.0.0",
+                    "bcrypt-pbkdf": "^1.0.0",
+                    "dashdash": "^1.12.0",
+                    "ecc-jsbn": "~0.1.1",
+                    "getpass": "^0.1.1",
+                    "jsbn": "~0.1.0",
+                    "tweetnacl": "~0.14.0"
                   },
                   "dependencies": {
                     "asn1": {
@@ -5798,14 +5923,14 @@
                       "bundled": true,
                       "optional": true,
                       "requires": {
-                        "tweetnacl": "0.14.5"
+                        "tweetnacl": "^0.14.3"
                       }
                     },
                     "dashdash": {
                       "version": "1.14.1",
                       "bundled": true,
                       "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                       }
                     },
                     "ecc-jsbn": {
@@ -5813,14 +5938,14 @@
                       "bundled": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "~0.1.0"
                       }
                     },
                     "getpass": {
                       "version": "0.1.7",
                       "bundled": true,
                       "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                       }
                     },
                     "jsbn": {
@@ -5853,7 +5978,7 @@
               "version": "2.1.18",
               "bundled": true,
               "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": "~1.33.0"
               },
               "dependencies": {
                 "mime-db": {
@@ -5882,7 +6007,7 @@
               "version": "2.3.4",
               "bundled": true,
               "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
               },
               "dependencies": {
                 "punycode": {
@@ -5895,7 +6020,7 @@
               "version": "0.6.0",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
               }
             }
           }
@@ -5908,7 +6033,7 @@
           "version": "2.6.2",
           "bundled": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -5923,8 +6048,8 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "readable-stream": "2.3.6"
+            "graceful-fs": "^4.1.2",
+            "readable-stream": "^2.0.2"
           }
         },
         "slide": {
@@ -5939,26 +6064,26 @@
           "version": "2.1.3",
           "bundled": true,
           "requires": {
-            "from2": "1.3.0",
-            "stream-iterate": "1.2.0"
+            "from2": "^1.3.0",
+            "stream-iterate": "^1.1.0"
           },
           "dependencies": {
             "from2": {
               "version": "1.3.0",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "1.1.14"
+                "inherits": "~2.0.1",
+                "readable-stream": "~1.1.10"
               },
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
                   "bundled": true,
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
+                    "string_decoder": "~0.10.x"
                   },
                   "dependencies": {
                     "core-util-is": {
@@ -5981,8 +6106,8 @@
               "version": "1.2.0",
               "bundled": true,
               "requires": {
-                "readable-stream": "2.3.6",
-                "stream-shift": "1.0.0"
+                "readable-stream": "^2.1.5",
+                "stream-shift": "^1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -5997,14 +6122,14 @@
           "version": "5.3.0",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "^5.1.1"
           }
         },
         "strip-ansi": {
           "version": "4.0.0",
           "bundled": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -6017,35 +6142,35 @@
           "version": "4.4.2",
           "bundled": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
           },
           "dependencies": {
             "fs-minipass": {
               "version": "1.2.5",
               "bundled": true,
               "requires": {
-                "minipass": "2.2.4"
+                "minipass": "^2.2.1"
               }
             },
             "minipass": {
               "version": "2.2.4",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.2",
-                "yallist": "3.0.2"
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.0"
               }
             },
             "minizlib": {
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "minipass": "2.2.4"
+                "minipass": "^2.2.1"
               }
             },
             "safe-buffer": {
@@ -6078,14 +6203,14 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "unique-slug": "2.0.0"
+            "unique-slug": "^2.0.0"
           },
           "dependencies": {
             "unique-slug": {
               "version": "2.0.0",
               "bundled": true,
               "requires": {
-                "imurmurhash": "0.1.4"
+                "imurmurhash": "^0.1.4"
               }
             }
           }
@@ -6098,36 +6223,36 @@
           "version": "2.5.0",
           "bundled": true,
           "requires": {
-            "boxen": "1.3.0",
-            "chalk": "2.4.1",
-            "configstore": "3.1.2",
-            "import-lazy": "2.1.0",
-            "is-ci": "1.1.0",
-            "is-installed-globally": "0.1.0",
-            "is-npm": "1.0.0",
-            "latest-version": "3.1.0",
-            "semver-diff": "2.1.0",
-            "xdg-basedir": "3.0.0"
+            "boxen": "^1.2.1",
+            "chalk": "^2.0.1",
+            "configstore": "^3.0.0",
+            "import-lazy": "^2.1.0",
+            "is-ci": "^1.0.10",
+            "is-installed-globally": "^0.1.0",
+            "is-npm": "^1.0.0",
+            "latest-version": "^3.0.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
           },
           "dependencies": {
             "boxen": {
               "version": "1.3.0",
               "bundled": true,
               "requires": {
-                "ansi-align": "2.0.0",
-                "camelcase": "4.1.0",
-                "chalk": "2.4.1",
-                "cli-boxes": "1.0.0",
-                "string-width": "2.1.1",
-                "term-size": "1.2.0",
-                "widest-line": "2.0.0"
+                "ansi-align": "^2.0.0",
+                "camelcase": "^4.0.0",
+                "chalk": "^2.0.1",
+                "cli-boxes": "^1.0.0",
+                "string-width": "^2.0.0",
+                "term-size": "^1.2.0",
+                "widest-line": "^2.0.0"
               },
               "dependencies": {
                 "ansi-align": {
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "string-width": "2.1.1"
+                    "string-width": "^2.0.0"
                   }
                 },
                 "camelcase": {
@@ -6142,8 +6267,8 @@
                   "version": "2.1.1",
                   "bundled": true,
                   "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "4.0.0"
+                    "is-fullwidth-code-point": "^2.0.0",
+                    "strip-ansi": "^4.0.0"
                   },
                   "dependencies": {
                     "is-fullwidth-code-point": {
@@ -6156,36 +6281,36 @@
                   "version": "1.2.0",
                   "bundled": true,
                   "requires": {
-                    "execa": "0.7.0"
+                    "execa": "^0.7.0"
                   },
                   "dependencies": {
                     "execa": {
                       "version": "0.7.0",
                       "bundled": true,
                       "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                       },
                       "dependencies": {
                         "cross-spawn": {
                           "version": "5.1.0",
                           "bundled": true,
                           "requires": {
-                            "lru-cache": "4.1.2",
-                            "shebang-command": "1.2.0",
-                            "which": "1.3.0"
+                            "lru-cache": "^4.0.1",
+                            "shebang-command": "^1.2.0",
+                            "which": "^1.2.9"
                           },
                           "dependencies": {
                             "shebang-command": {
                               "version": "1.2.0",
                               "bundled": true,
                               "requires": {
-                                "shebang-regex": "1.0.0"
+                                "shebang-regex": "^1.0.0"
                               },
                               "dependencies": {
                                 "shebang-regex": {
@@ -6208,7 +6333,7 @@
                           "version": "2.0.2",
                           "bundled": true,
                           "requires": {
-                            "path-key": "2.0.1"
+                            "path-key": "^2.0.0"
                           },
                           "dependencies": {
                             "path-key": {
@@ -6237,7 +6362,7 @@
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "string-width": "2.1.1"
+                    "string-width": "^2.1.1"
                   }
                 }
               }
@@ -6246,23 +6371,23 @@
               "version": "2.4.1",
               "bundled": true,
               "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.4.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
               },
               "dependencies": {
                 "ansi-styles": {
                   "version": "3.2.1",
                   "bundled": true,
                   "requires": {
-                    "color-convert": "1.9.1"
+                    "color-convert": "^1.9.0"
                   },
                   "dependencies": {
                     "color-convert": {
                       "version": "1.9.1",
                       "bundled": true,
                       "requires": {
-                        "color-name": "1.1.3"
+                        "color-name": "^1.1.1"
                       },
                       "dependencies": {
                         "color-name": {
@@ -6281,7 +6406,7 @@
                   "version": "5.4.0",
                   "bundled": true,
                   "requires": {
-                    "has-flag": "3.0.0"
+                    "has-flag": "^3.0.0"
                   },
                   "dependencies": {
                     "has-flag": {
@@ -6296,19 +6421,19 @@
               "version": "3.1.2",
               "bundled": true,
               "requires": {
-                "dot-prop": "4.2.0",
-                "graceful-fs": "4.1.11",
-                "make-dir": "1.2.0",
-                "unique-string": "1.0.0",
-                "write-file-atomic": "2.3.0",
-                "xdg-basedir": "3.0.0"
+                "dot-prop": "^4.1.0",
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^1.0.0",
+                "unique-string": "^1.0.0",
+                "write-file-atomic": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
               },
               "dependencies": {
                 "dot-prop": {
                   "version": "4.2.0",
                   "bundled": true,
                   "requires": {
-                    "is-obj": "1.0.1"
+                    "is-obj": "^1.0.0"
                   },
                   "dependencies": {
                     "is-obj": {
@@ -6321,7 +6446,7 @@
                   "version": "1.2.0",
                   "bundled": true,
                   "requires": {
-                    "pify": "3.0.0"
+                    "pify": "^3.0.0"
                   },
                   "dependencies": {
                     "pify": {
@@ -6334,7 +6459,7 @@
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "crypto-random-string": "1.0.0"
+                    "crypto-random-string": "^1.0.0"
                   },
                   "dependencies": {
                     "crypto-random-string": {
@@ -6353,7 +6478,7 @@
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "ci-info": "1.1.3"
+                "ci-info": "^1.0.0"
               },
               "dependencies": {
                 "ci-info": {
@@ -6366,22 +6491,22 @@
               "version": "0.1.0",
               "bundled": true,
               "requires": {
-                "global-dirs": "0.1.1",
-                "is-path-inside": "1.0.1"
+                "global-dirs": "^0.1.0",
+                "is-path-inside": "^1.0.0"
               },
               "dependencies": {
                 "global-dirs": {
                   "version": "0.1.1",
                   "bundled": true,
                   "requires": {
-                    "ini": "1.3.5"
+                    "ini": "^1.3.4"
                   }
                 },
                 "is-path-inside": {
                   "version": "1.0.1",
                   "bundled": true,
                   "requires": {
-                    "path-is-inside": "1.0.2"
+                    "path-is-inside": "^1.0.1"
                   }
                 }
               }
@@ -6394,41 +6519,41 @@
               "version": "3.1.0",
               "bundled": true,
               "requires": {
-                "package-json": "4.0.1"
+                "package-json": "^4.0.0"
               },
               "dependencies": {
                 "package-json": {
                   "version": "4.0.1",
                   "bundled": true,
                   "requires": {
-                    "got": "6.7.1",
-                    "registry-auth-token": "3.3.2",
-                    "registry-url": "3.1.0",
-                    "semver": "5.5.0"
+                    "got": "^6.7.1",
+                    "registry-auth-token": "^3.0.1",
+                    "registry-url": "^3.0.3",
+                    "semver": "^5.1.0"
                   },
                   "dependencies": {
                     "got": {
                       "version": "6.7.1",
                       "bundled": true,
                       "requires": {
-                        "create-error-class": "3.0.2",
-                        "duplexer3": "0.1.4",
-                        "get-stream": "3.0.0",
-                        "is-redirect": "1.0.0",
-                        "is-retry-allowed": "1.1.0",
-                        "is-stream": "1.1.0",
-                        "lowercase-keys": "1.0.1",
-                        "safe-buffer": "5.1.2",
-                        "timed-out": "4.0.1",
-                        "unzip-response": "2.0.1",
-                        "url-parse-lax": "1.0.0"
+                        "create-error-class": "^3.0.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^3.0.0",
+                        "is-redirect": "^1.0.0",
+                        "is-retry-allowed": "^1.0.0",
+                        "is-stream": "^1.0.0",
+                        "lowercase-keys": "^1.0.0",
+                        "safe-buffer": "^5.0.1",
+                        "timed-out": "^4.0.0",
+                        "unzip-response": "^2.0.1",
+                        "url-parse-lax": "^1.0.0"
                       },
                       "dependencies": {
                         "create-error-class": {
                           "version": "3.0.2",
                           "bundled": true,
                           "requires": {
-                            "capture-stack-trace": "1.0.0"
+                            "capture-stack-trace": "^1.0.0"
                           },
                           "dependencies": {
                             "capture-stack-trace": {
@@ -6473,7 +6598,7 @@
                           "version": "1.0.0",
                           "bundled": true,
                           "requires": {
-                            "prepend-http": "1.0.4"
+                            "prepend-http": "^1.0.1"
                           },
                           "dependencies": {
                             "prepend-http": {
@@ -6488,18 +6613,18 @@
                       "version": "3.3.2",
                       "bundled": true,
                       "requires": {
-                        "rc": "1.2.7",
-                        "safe-buffer": "5.1.2"
+                        "rc": "^1.1.6",
+                        "safe-buffer": "^5.0.1"
                       },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.7",
                           "bundled": true,
                           "requires": {
-                            "deep-extend": "0.5.1",
-                            "ini": "1.3.5",
-                            "minimist": "1.2.0",
-                            "strip-json-comments": "2.0.1"
+                            "deep-extend": "^0.5.1",
+                            "ini": "~1.3.0",
+                            "minimist": "^1.2.0",
+                            "strip-json-comments": "~2.0.1"
                           },
                           "dependencies": {
                             "deep-extend": {
@@ -6522,17 +6647,17 @@
                       "version": "3.1.0",
                       "bundled": true,
                       "requires": {
-                        "rc": "1.2.7"
+                        "rc": "^1.0.1"
                       },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.7",
                           "bundled": true,
                           "requires": {
-                            "deep-extend": "0.5.1",
-                            "ini": "1.3.5",
-                            "minimist": "1.2.0",
-                            "strip-json-comments": "2.0.1"
+                            "deep-extend": "^0.5.1",
+                            "ini": "~1.3.0",
+                            "minimist": "^1.2.0",
+                            "strip-json-comments": "~2.0.1"
                           },
                           "dependencies": {
                             "deep-extend": {
@@ -6559,7 +6684,7 @@
               "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "semver": "5.5.0"
+                "semver": "^5.0.3"
               }
             },
             "xdg-basedir": {
@@ -6576,16 +6701,16 @@
           "version": "3.0.3",
           "bundled": true,
           "requires": {
-            "spdx-correct": "3.0.0",
-            "spdx-expression-parse": "3.0.0"
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
           },
           "dependencies": {
             "spdx-correct": {
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
               },
               "dependencies": {
                 "spdx-license-ids": {
@@ -6598,8 +6723,8 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
               },
               "dependencies": {
                 "spdx-exceptions": {
@@ -6618,7 +6743,7 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "builtins": "1.0.3"
+            "builtins": "^1.0.3"
           },
           "dependencies": {
             "builtins": {
@@ -6631,7 +6756,7 @@
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           },
           "dependencies": {
             "isexe": {
@@ -6644,14 +6769,14 @@
           "version": "1.6.0",
           "bundled": true,
           "requires": {
-            "errno": "0.1.7"
+            "errno": "~0.1.7"
           },
           "dependencies": {
             "errno": {
               "version": "0.1.7",
               "bundled": true,
               "requires": {
-                "prr": "1.0.1"
+                "prr": "~1.0.1"
               },
               "dependencies": {
                 "prr": {
@@ -6670,9 +6795,9 @@
           "version": "2.3.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "signal-exit": "3.0.2"
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
           },
           "dependencies": {
             "signal-exit": {
@@ -6709,9 +6834,9 @@
       "resolved": "https://registry.npmjs.org/object-extended/-/object-extended-0.0.7.tgz",
       "integrity": "sha1-hP0j9WsVWCrrPoiwXLVdJDLWijM=",
       "requires": {
-        "array-extended": "0.0.11",
-        "extended": "0.0.6",
-        "is-extended": "0.0.10"
+        "array-extended": "~0.0.4",
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.3"
       }
     },
     "once": {
@@ -6720,7 +6845,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -6734,8 +6859,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -6751,12 +6876,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -6779,14 +6904,14 @@
       "integrity": "sha512-cDNAN1Ehjbf5EHkNY5qnRhGPUCp6SnpyVof5fRzN800QV1Y2OkzbH9rmjZkbBRa8igof903yOnjIl6z0SlAhxA==",
       "dev": true,
       "requires": {
-        "agent-base": "4.2.0",
-        "debug": "3.1.0",
-        "get-uri": "2.0.2",
-        "http-proxy-agent": "2.1.0",
-        "https-proxy-agent": "2.2.1",
-        "pac-resolver": "3.0.0",
-        "raw-body": "2.3.3",
-        "socks-proxy-agent": "3.0.1"
+        "agent-base": "^4.2.0",
+        "debug": "^3.1.0",
+        "get-uri": "^2.0.0",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1",
+        "pac-resolver": "^3.0.0",
+        "raw-body": "^2.2.0",
+        "socks-proxy-agent": "^3.0.0"
       },
       "dependencies": {
         "debug": {
@@ -6803,14 +6928,14 @@
     "pac-resolver": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-3.0.0.tgz",
-      "integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
+      "integrity": "sha1-auoweH2wqJFwTet4AKcip2FabyY=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "degenerator": "1.0.4",
-        "ip": "1.1.5",
-        "netmask": "1.0.6",
-        "thunkify": "2.1.2"
+        "co": "^4.6.0",
+        "degenerator": "^1.0.4",
+        "ip": "^1.1.5",
+        "netmask": "^1.0.6",
+        "thunkify": "^2.1.2"
       }
     },
     "packet-reader": {
@@ -6872,9 +6997,9 @@
         "buffer-writer": "1.0.1",
         "packet-reader": "0.3.1",
         "pg-connection-string": "0.1.3",
-        "pg-pool": "2.0.3",
-        "pg-types": "1.12.1",
-        "pgpass": "1.0.2",
+        "pg-pool": "~2.0.3",
+        "pg-types": "~1.12.1",
+        "pgpass": "1.x",
         "semver": "4.3.2"
       }
     },
@@ -6891,7 +7016,7 @@
     "pg-minify": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-0.5.4.tgz",
-      "integrity": "sha512-GHB2v4OiMHDgwiHH86ZWNfvgEPVijrnfuWLQocseX6Zlf30k+x0imA65zBy4skIpEwfBBEplIEEKP4n3q9KkVA=="
+      "integrity": "sha1-idUmHKz9RN15J/oFIiKkBOmyo8k="
     },
     "pg-pool": {
       "version": "2.0.3",
@@ -6901,12 +7026,12 @@
     "pg-promise": {
       "version": "5.9.7",
       "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-5.9.7.tgz",
-      "integrity": "sha512-Hp53E6qdjxyuNepIpr7ONbsKZ2GYfi+HbuW4VNMfWcCSZPlE/A9DieYc82AJaz2f9eHcmByeU7TiQTmsBu3hGA==",
+      "integrity": "sha1-THj1gGHPBNavqGuqzwvdDPgoHI4=",
       "requires": {
-        "manakin": "0.4.8",
-        "pg": "5.2.1",
-        "pg-minify": "0.4.5",
-        "spex": "1.2.1"
+        "manakin": "^0.4.7",
+        "pg": "^5.1.0",
+        "pg-minify": "0.4",
+        "spex": "1.2"
       },
       "dependencies": {
         "manakin": {
@@ -6928,8 +7053,8 @@
             "js-string-escape": "1.0.1",
             "packet-reader": "0.2.0",
             "pg-connection-string": "0.1.3",
-            "pg-pool": "1.8.0",
-            "pg-types": "1.12.1",
+            "pg-pool": "1.*",
+            "pg-types": "1.*",
             "pgpass": "0.0.6",
             "semver": "4.3.2"
           }
@@ -6937,7 +7062,7 @@
         "pg-minify": {
           "version": "0.4.5",
           "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-0.4.5.tgz",
-          "integrity": "sha512-ev7PZ4ySzTnNPaeIJQx4f94ubqbv2C48lpXcYLPzPD4dbnKxzvC+3vNlZZ8HYx9JV37AxaLlY/LzrpFBgBslYQ=="
+          "integrity": "sha1-0+kvtpD5KDuKN4ZuRWb86f7SYVA="
         },
         "pg-pool": {
           "version": "1.8.0",
@@ -6953,13 +7078,13 @@
           "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-0.0.6.tgz",
           "integrity": "sha1-9idiANAXOdoe6mMTi9yjX/S9coA=",
           "requires": {
-            "split": "1.0.1"
+            "split": "^1.0.0"
           }
         },
         "spex": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/spex/-/spex-1.2.1.tgz",
-          "integrity": "sha512-+qhIg5QJZQTSk6TBUmXnptB6irHR6trN0Vb+LUQBwe8cKDFf+aLBohhsRGwuoBSZglCHG+V+CMh/DBFDb/i8Gg=="
+          "integrity": "sha1-GMMSdUC0V6CKcdDvAYpXjKJIC4k="
         }
       }
     },
@@ -6976,10 +7101,10 @@
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
       "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
       "requires": {
-        "postgres-array": "1.0.2",
-        "postgres-bytea": "1.0.0",
-        "postgres-date": "1.0.3",
-        "postgres-interval": "1.1.1"
+        "postgres-array": "~1.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.0",
+        "postgres-interval": "^1.1.0"
       }
     },
     "pgpass": {
@@ -6987,7 +7112,7 @@
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
       "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
       "requires": {
-        "split": "1.0.1"
+        "split": "^1.0.0"
       }
     },
     "picture-tube": {
@@ -6995,13 +7120,13 @@
       "resolved": "https://registry.npmjs.org/picture-tube/-/picture-tube-0.0.4.tgz",
       "integrity": "sha1-Id4Ctxecy3OvCD8RL1JnYy/G6MY=",
       "requires": {
-        "buffers": "0.1.1",
-        "charm": "0.1.2",
-        "event-stream": "0.9.8",
-        "optimist": "0.3.7",
-        "png-js": "0.1.1",
-        "request": "2.9.203",
-        "x256": "0.0.2"
+        "buffers": "~0.1.1",
+        "charm": "~0.1.0",
+        "event-stream": "~0.9.8",
+        "optimist": "~0.3.4",
+        "png-js": "~0.1.0",
+        "request": "~2.9.202",
+        "x256": "~0.0.1"
       },
       "dependencies": {
         "optimist": {
@@ -7009,7 +7134,7 @@
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
           "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
           "requires": {
-            "wordwrap": "0.0.3"
+            "wordwrap": "~0.0.2"
           }
         },
         "request": {
@@ -7037,7 +7162,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-config": {
@@ -7046,9 +7171,9 @@
       "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
       "dev": true,
       "requires": {
-        "debug-log": "1.0.1",
-        "find-root": "1.1.0",
-        "xtend": "4.0.1"
+        "debug-log": "^1.0.0",
+        "find-root": "^1.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "pkginfo": {
@@ -7085,9 +7210,9 @@
     "postgres-interval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.1.tgz",
-      "integrity": "sha512-OkuCi9t/3CZmeQreutGgx/OVNv9MKHGIT5jH8KldQ4NLYXkvmT9nDVxEuCENlNwhlGPE374oA/xMqn05G49pHA==",
+      "integrity": "sha1-rNsPiXtLHG5JbZ1OCoU+HEKPBvA=",
       "requires": {
-        "xtend": "4.0.1"
+        "xtend": "^4.0.0"
       }
     },
     "prelude-ls": {
@@ -7099,7 +7224,7 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o="
     },
     "progress": {
       "version": "1.1.8",
@@ -7110,9 +7235,9 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "promised-io": {
@@ -7127,14 +7252,14 @@
       "integrity": "sha512-CNKuhC1jVtm8KJYFTS2ZRO71VCBx3QSA92So/e6NrY6GoJonkx3Irnk4047EsCcswczwqAekRj3s8qLRGahSKg==",
       "dev": true,
       "requires": {
-        "agent-base": "4.2.0",
-        "debug": "3.1.0",
-        "http-proxy-agent": "2.1.0",
-        "https-proxy-agent": "2.2.1",
-        "lru-cache": "4.1.3",
-        "pac-proxy-agent": "2.0.2",
-        "proxy-from-env": "1.0.0",
-        "socks-proxy-agent": "3.0.1"
+        "agent-base": "^4.2.0",
+        "debug": "^3.1.0",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1",
+        "lru-cache": "^4.1.2",
+        "pac-proxy-agent": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "socks-proxy-agent": "^3.0.0"
       },
       "dependencies": {
         "debug": {
@@ -7192,13 +7317,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readline2": {
@@ -7207,8 +7332,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
         "mute-stream": "0.0.5"
       }
     },
@@ -7217,7 +7342,7 @@
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
       "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
       "requires": {
-        "esprima": "3.0.0"
+        "esprima": "~3.0.0"
       }
     },
     "remove-trailing-separator": {
@@ -7231,27 +7356,27 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.86.0.tgz",
       "integrity": "sha512-BQZih67o9r+Ys94tcIW4S7Uu8pthjrQVxhsZ/weOwHbDfACxvIyvnAbzFQxjy1jMtvFSzv5zf4my6cZsJBbVzw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "require-uncached": {
@@ -7260,8 +7385,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -7275,16 +7400,16 @@
     "require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "integrity": "sha1-TPNaQkf2TKPfjC7yCMxJSxyo/C4=",
       "requires": {
-        "resolve-from": "2.0.0",
-        "semver": "5.5.0"
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
       },
       "dependencies": {
         "semver": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+          "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs="
         }
       }
     },
@@ -7294,7 +7419,7 @@
       "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-from": {
@@ -7308,17 +7433,17 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
       "dev": true,
       "requires": {
-        "glob": "7.1.1"
+        "glob": "^7.0.5"
       }
     },
     "run-async": {
@@ -7327,7 +7452,7 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.0"
       }
     },
     "run-parallel": {
@@ -7356,7 +7481,7 @@
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA=",
       "dev": true
     },
     "sax": {
@@ -7390,20 +7515,20 @@
     "sinon": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-3.3.0.tgz",
-      "integrity": "sha512-/flfGfIxIRXSvZBHJzIf3iAyGYkmMQq6SQjA0cx9SOuVuq+4ZPPO4LJtH1Ce0Lznax1KSG1U6Dad85wIcSW19w==",
+      "integrity": "sha1-kTIRG0u+E8dJwoSCEIZCUBZQabE=",
       "dev": true,
       "requires": {
-        "build": "0.1.4",
-        "diff": "3.2.0",
+        "build": "^0.1.4",
+        "diff": "^3.1.0",
         "formatio": "1.2.0",
-        "lodash.get": "4.4.2",
-        "lolex": "2.6.0",
-        "native-promise-only": "0.8.1",
-        "nise": "1.3.3",
-        "path-to-regexp": "1.7.0",
-        "samsam": "1.3.0",
+        "lodash.get": "^4.4.2",
+        "lolex": "^2.1.2",
+        "native-promise-only": "^0.8.1",
+        "nise": "^1.0.1",
+        "path-to-regexp": "^1.7.0",
+        "samsam": "^1.1.3",
         "text-encoding": "0.6.4",
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "slice-ansi": {
@@ -7421,9 +7546,9 @@
     "sntp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "socks": {
@@ -7432,24 +7557,24 @@
       "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
       "dev": true,
       "requires": {
-        "ip": "1.1.5",
-        "smart-buffer": "1.1.15"
+        "ip": "^1.1.4",
+        "smart-buffer": "^1.0.13"
       }
     },
     "socks-proxy-agent": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-3.0.1.tgz",
-      "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
+      "integrity": "sha1-Lq58+OKoLTRWV2FTmn+XGMVhdlk=",
       "dev": true,
       "requires": {
-        "agent-base": "4.2.0",
-        "socks": "1.1.10"
+        "agent-base": "^4.1.0",
+        "socks": "^1.1.10"
       }
     },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true,
       "optional": true
     },
@@ -7459,20 +7584,20 @@
       "integrity": "sha1-w73kYlKxNU5xDEsgDVSBa9nwejI=",
       "requires": {
         "here": "0.0.2",
-        "nopt": "2.1.2"
+        "nopt": "~2.1.2"
       }
     },
     "spex": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/spex/-/spex-2.0.2.tgz",
-      "integrity": "sha512-LU6TS3qTEpRth+FnNs/fIWEmridYN7JmaN2k1Jk31XVC4ex7+wYxiHMnKguRxS7oKjbOFl4H6seeWNDFFgkVRg=="
+      "integrity": "sha1-6MjWM6TGevZC3e1wHsI1DJ3pZKA="
     },
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "sprintf-js": {
@@ -7486,14 +7611,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stack-trace": {
@@ -7507,14 +7632,14 @@
       "integrity": "sha1-sOZl4yJ32jy5nyEmmxBC2B7+sGs=",
       "dev": true,
       "requires": {
-        "eslint": "2.2.0",
+        "eslint": "~2.2.0",
         "eslint-config-standard": "5.1.0",
         "eslint-config-standard-jsx": "1.1.1",
-        "eslint-plugin-promise": "1.3.2",
-        "eslint-plugin-react": "4.3.0",
-        "eslint-plugin-standard": "1.3.3",
-        "standard-engine": "3.3.1",
-        "xtend": "4.0.1"
+        "eslint-plugin-promise": "^1.0.8",
+        "eslint-plugin-react": "^4.0.0",
+        "eslint-plugin-standard": "^1.3.1",
+        "standard-engine": "^3.3.0",
+        "xtend": "^4.0.1"
       }
     },
     "standard-engine": {
@@ -7523,14 +7648,14 @@
       "integrity": "sha1-sveY3k5NPh+s7UJcgTaDGmZ0CO0=",
       "dev": true,
       "requires": {
-        "defaults": "1.0.3",
-        "deglob": "1.1.2",
-        "find-root": "1.1.0",
-        "get-stdin": "5.0.1",
-        "minimist": "1.2.0",
-        "multiline": "1.0.2",
-        "pkg-config": "1.1.1",
-        "xtend": "4.0.1"
+        "defaults": "^1.0.2",
+        "deglob": "^1.0.0",
+        "find-root": "^1.0.0",
+        "get-stdin": "^5.0.1",
+        "minimist": "^1.1.0",
+        "multiline": "^1.0.2",
+        "pkg-config": "^1.0.1",
+        "xtend": "^4.0.0"
       }
     },
     "statuses": {
@@ -7544,10 +7669,10 @@
       "resolved": "https://registry.npmjs.org/string-extended/-/string-extended-0.0.8.tgz",
       "integrity": "sha1-dBlX3/SHsCcqee7FpE8jnubxfM0=",
       "requires": {
-        "array-extended": "0.0.11",
-        "date-extended": "0.0.6",
-        "extended": "0.0.6",
-        "is-extended": "0.0.10"
+        "array-extended": "~0.0.5",
+        "date-extended": "~0.0.3",
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.3"
       }
     },
     "string-width": {
@@ -7556,9 +7681,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -7566,7 +7691,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -7574,7 +7699,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-indent": {
@@ -7583,7 +7708,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       },
       "dependencies": {
         "get-stdin": {
@@ -7608,13 +7733,13 @@
     "sync-request": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-4.1.0.tgz",
-      "integrity": "sha512-iFbOBWYaznBNbheIKaMkj+3EabpEsXbuwcTVuYkRjoav+Om5L8VXXLIXms0cHxkouXMRCQaSfhfau9/HyIbM2Q==",
+      "integrity": "sha1-MktOUG+5lNKv0qACGkVfgAcl8Ho=",
       "requires": {
-        "command-exists": "1.2.6",
-        "concat-stream": "1.6.2",
-        "get-port": "3.2.0",
-        "http-response-object": "1.1.0",
-        "then-request": "2.2.0"
+        "command-exists": "^1.2.2",
+        "concat-stream": "^1.6.0",
+        "get-port": "^3.1.0",
+        "http-response-object": "^1.1.0",
+        "then-request": "^2.2.0"
       }
     },
     "table": {
@@ -7623,12 +7748,12 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
-        "lodash": "4.17.10",
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.0.0",
+        "chalk": "^1.1.1",
+        "lodash": "^4.0.0",
         "slice-ansi": "0.0.4",
-        "string-width": "2.1.1"
+        "string-width": "^2.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -7637,8 +7762,8 @@
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "ansi-regex": {
@@ -7656,11 +7781,11 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -7669,7 +7794,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -7680,13 +7805,13 @@
       "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
       "dev": true,
       "requires": {
-        "bl": "1.2.2",
-        "buffer-alloc": "1.1.0",
-        "end-of-stream": "1.4.1",
-        "fs-constants": "1.0.0",
-        "readable-stream": "2.3.6",
-        "to-buffer": "1.1.1",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.1.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.0",
+        "xtend": "^4.0.0"
       }
     },
     "term-canvas": {
@@ -7711,12 +7836,12 @@
       "resolved": "https://registry.npmjs.org/then-request/-/then-request-2.2.0.tgz",
       "integrity": "sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=",
       "requires": {
-        "caseless": "0.11.0",
-        "concat-stream": "1.6.2",
-        "http-basic": "2.5.1",
-        "http-response-object": "1.1.0",
-        "promise": "7.3.1",
-        "qs": "6.5.2"
+        "caseless": "~0.11.0",
+        "concat-stream": "^1.4.7",
+        "http-basic": "^2.5.1",
+        "http-response-object": "^1.1.0",
+        "promise": "^7.1.1",
+        "qs": "^6.1.0"
       },
       "dependencies": {
         "caseless": {
@@ -7758,17 +7883,23 @@
     "tough-cookie": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
+    },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -7783,13 +7914,13 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
       "dev": true
     },
     "typedarray": {
@@ -7843,7 +7974,7 @@
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "util-deprecate": {
@@ -7854,16 +7985,16 @@
     "uuid": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "integrity": "sha1-EsUou51Y0LkmXZovbw/ovhf/HxQ="
     },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "walker": {
@@ -7872,7 +8003,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
-        "makeerror": "1.0.11"
+        "makeerror": "1.0.x"
       }
     },
     "winston": {
@@ -7880,12 +8011,12 @@
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.2.tgz",
       "integrity": "sha512-4S/Ad4ZfSNl8OccCLxnJmNISWcm2joa6Q0YGDxlxMzH0fgSwWsjMt+SmlNwCqdpaPg3ev1HKkMBsIiXeSUwpbA==",
       "requires": {
-        "async": "1.0.0",
-        "colors": "1.0.3",
-        "cycle": "1.0.3",
-        "eyes": "0.1.8",
-        "isstream": "0.1.2",
-        "stack-trace": "0.0.10"
+        "async": "~1.0.0",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "stack-trace": "0.0.x"
       }
     },
     "wordwrap": {
@@ -7911,7 +8042,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "x256": {
@@ -7924,8 +8055,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
       "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
       "requires": {
-        "sax": "1.2.1",
-        "xmlbuilder": "4.2.1"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "^4.1.0"
       }
     },
     "xmlbuilder": {
@@ -7933,7 +8064,7 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
       "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.0.0"
       }
     },
     "xmldom": {
@@ -7964,10 +8095,10 @@
       "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
       "dev": true,
       "requires": {
-        "archiver-utils": "1.3.0",
-        "compress-commons": "1.2.2",
-        "lodash": "4.17.10",
-        "readable-stream": "2.3.6"
+        "archiver-utils": "^1.3.0",
+        "compress-commons": "^1.2.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "sync-request": "^4.1.0"
   },
   "devDependencies": {
+    "aws-sdk-mock": "^4.1.0",
     "chai": "^4.1.2",
     "dotenv": "^4.0.0",
     "minimist": "^1.2.0",

--- a/test/data/b10011745suppressed.json
+++ b/test/data/b10011745suppressed.json
@@ -1,0 +1,3915 @@
+{
+  "subject_id": "b10011745suppressed",
+  "bib_statements": [
+    {
+      "bn": null,
+      "id": "carriertypes:nc",
+      "la": "volume",
+      "li": null,
+      "pr": "bf:carrier"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "24 cm.",
+      "pr": "bf:dimensions"
+    },
+    {
+      "bn": null,
+      "id": "urn:biblevel:s",
+      "la": "serial",
+      "li": null,
+      "pr": "bf:issuance"
+    },
+    {
+      "bn": null,
+      "id": "mediatypes:n",
+      "la": "unmediated",
+      "li": null,
+      "pr": "bf:media"
+    },
+    {
+      "bn": [
+        {
+          "id": null,
+          "la": null,
+          "li": "Issued By",
+          "pr": "bf:noteType"
+        },
+        {
+          "id": null,
+          "la": null,
+          "li": "Official journal of the International Society for the Study of Behavioral Development.",
+          "pr": "rdfs:label"
+        },
+        {
+          "id": "bf:Note",
+          "la": null,
+          "li": null,
+          "pr": "rdf:type"
+        }
+      ],
+      "id": "b10011745#1.0000",
+      "la": null,
+      "li": null,
+      "pr": "bf:note"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "9999",
+      "pr": "dbo:endDate"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "1978",
+      "pr": "dbo:startDate"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "International Society for the Study of Behavioral Development.",
+      "pr": "dc:contributor"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "1978",
+      "pr": "dc:date"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Etiquette -- Periodicals.",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Developmental psychology -- Periodicals.",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Behaviorism (psychology) -- Periodicals.",
+      "pr": "dc:subject"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Int. j. behav. dev.",
+      "pr": "dcterms:alternative"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "International journal of behavioral development",
+      "pr": "dcterms:alternative"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "IJBD",
+      "pr": "dcterms:alternative"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "1978",
+      "pr": "dcterms:created"
+    },
+    {
+      "bn": null,
+      "id": "urn:bnum:10011745",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "bn": null,
+      "id": "urn:issn:0165-0254",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "bn": null,
+      "id": "urn:lccn:sc 79005623 ",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "bn": null,
+      "id": "lang:eng",
+      "la": "English",
+      "li": null,
+      "pr": "dcterms:language"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "International journal of behavioral development.",
+      "pr": "dcterms:title"
+    },
+    {
+      "bn": null,
+      "id": "resourcetypes:txt",
+      "la": "Text",
+      "li": null,
+      "pr": "dcterms:type"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "v. ill.",
+      "pr": "nypl:extent"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Amsterdam,",
+      "pr": "nypl:placeOfPublication"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Amsterdam, North-Holland.",
+      "pr": "nypl:publicationStatement"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "North-Holland.",
+      "pr": "nypl:role-publisher"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "v. 1-   Jan. 1978-",
+      "pr": "nypl:serialPublicationDates"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "International journal of behavioral development.",
+      "pr": "nypl:titleDisplay"
+    },
+    {
+      "bn": null,
+      "id": "nypl:Collection",
+      "la": null,
+      "li": null,
+      "pr": "rdfs:type"
+    }
+  ],
+  "item_statements": [
+    {
+      "s": "i28877180",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877180",
+      "bn": null,
+      "id": "urn:barcode:33433101580961",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877180",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877180",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877180",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877180",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877180",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877180",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877180",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 30, no. 2 (Mar 2006)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877180",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877180",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877188",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877188",
+      "bn": null,
+      "id": "urn:barcode:33433101581043",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877188",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877188",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877188",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877188",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877188",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877188",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877188",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 31, no. 4 (Jul 2007)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877188",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877188",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877202",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877202",
+      "bn": null,
+      "id": "urn:barcode:33433101581175",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877202",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877202",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877202",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877202",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877202",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877202",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877202",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 33, no. 5 (Sept 2009)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877202",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877202",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877203",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877203",
+      "bn": null,
+      "id": "urn:barcode:33433101581183",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877203",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877203",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877203",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877203",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877203",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877203",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877203",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 33, no. 6 (Nov 2009)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877203",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877203",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877187",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877187",
+      "bn": null,
+      "id": "urn:barcode:33433101581035",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877187",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877187",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877187",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877187",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877187",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877187",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877187",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 31, no. 3 (May 2007)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877187",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877187",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877184",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877184",
+      "bn": null,
+      "id": "urn:barcode:33433101581001",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877184",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877184",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877184",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877184",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877184",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877184",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877184",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 30, no. 6 (Nov 2006)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877184",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877184",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877195",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877195",
+      "bn": null,
+      "id": "urn:barcode:33433101581118",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877195",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877195",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877195",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877195",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877195",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877195",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877195",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 32, no. 5 (Sept 2008)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877195",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877195",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877177",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877177",
+      "bn": null,
+      "id": "urn:barcode:33433101580938",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877177",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877177",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877177",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877177",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877177",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877177",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877177",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 29, no. 5 (Sept 2005)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877177",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877177",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877200",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877200",
+      "bn": null,
+      "id": "urn:barcode:33433101581167",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877200",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877200",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877200",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877200",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877200",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877200",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877200",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 33, no. 4 (Jul 2009)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877200",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877200",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877181",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877181",
+      "bn": null,
+      "id": "urn:barcode:33433101580979",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877181",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877181",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877181",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877181",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877181",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877181",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877181",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 30, no. 3 (May 2006)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877181",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877181",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877178",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877178",
+      "bn": null,
+      "id": "urn:barcode:33433101580946",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877178",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877178",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877178",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877178",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877178",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877178",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877178",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 29, no. 6 (Nov 2005)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877178",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877178",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877175",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877175",
+      "bn": null,
+      "id": "urn:barcode:33433101580912",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877175",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877175",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877175",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877175",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877175",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877175",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877175",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 29, no. 3 (May 2005)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877175",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877175",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877182",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877182",
+      "bn": null,
+      "id": "urn:barcode:33433101580987",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877182",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877182",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877182",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877182",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877182",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877182",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877182",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 30, no. 4 (Jul 2006)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877182",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877182",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877183",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877183",
+      "bn": null,
+      "id": "urn:barcode:33433101580995",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877183",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877183",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877183",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877183",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877183",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877183",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877183",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 30, no. 5 (Sept 2006)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877183",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877183",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877186",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877186",
+      "bn": null,
+      "id": "urn:barcode:33433101581027",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877186",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877186",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877186",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877186",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877186",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877186",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877186",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 31, no. 2 (Mar 2007)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877186",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877186",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877176",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877176",
+      "bn": null,
+      "id": "urn:barcode:33433101580920",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877176",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877176",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877176",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877176",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877176",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877176",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877176",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 29, no. 4 (Jul 2005)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877176",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877176",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877185",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877185",
+      "bn": null,
+      "id": "urn:barcode:33433101581019",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877185",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877185",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877185",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877185",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877185",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877185",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877185",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 31, no. 1 (Jan 2007)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877185",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877185",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877174",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877174",
+      "bn": null,
+      "id": "urn:barcode:33433101580904",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877174",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877174",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877174",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877174",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877174",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877174",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877174",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 29, no. 2 (Mar 2005)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877174",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877174",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877189",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877189",
+      "bn": null,
+      "id": "urn:barcode:33433101581050",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877189",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877189",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877189",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877189",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877189",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877189",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877189",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 31, no. 5 (Sept 2007)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877189",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877189",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877191",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877191",
+      "bn": null,
+      "id": "urn:barcode:33433101581076",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877191",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877191",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877191",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877191",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877191",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877191",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877191",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 32, no. 1 (Jan 2008)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877191",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877191",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877190",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877190",
+      "bn": null,
+      "id": "urn:barcode:33433101581068",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877190",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877190",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877190",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877190",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877190",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877190",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877190",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 31, no. 6 (Nov 2007)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877190",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877190",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877196",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877196",
+      "bn": null,
+      "id": "urn:barcode:33433101581126",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877196",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877196",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877196",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877196",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877196",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877196",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877196",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 32, no. 6 (Nov 2008)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877196",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877196",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877194",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877194",
+      "bn": null,
+      "id": "urn:barcode:33433101581100",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877194",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877194",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877194",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877194",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877194",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877194",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877194",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 32, no. 4 (Jul 2008)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877194",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877194",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877179",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877179",
+      "bn": null,
+      "id": "urn:barcode:33433101580953",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877179",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877179",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877179",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877179",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877179",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877179",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877179",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 30, no. 1 (Jan 2006)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877179",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877179",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877193",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877193",
+      "bn": null,
+      "id": "urn:barcode:33433101581092",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877193",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877193",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877193",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877193",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877193",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877193",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877193",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 32, no. 3 (May 2008)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877193",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877193",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877192",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877192",
+      "bn": null,
+      "id": "urn:barcode:33433101581084",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877192",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877192",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877192",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877192",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877192",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877192",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877192",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 32, no. 2 (Mar 2008)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877192",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877192",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877197",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877197",
+      "bn": null,
+      "id": "urn:barcode:33433101581134",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877197",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877197",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877197",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877197",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877197",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877197",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877197",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 33, no. 1 (Jan 2009)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877197",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877197",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877173",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877173",
+      "bn": null,
+      "id": "urn:barcode:33433101580896",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877173",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877173",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877173",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877173",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877173",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877173",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877173",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 29, no. 1 (Jan 2005)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877173",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877173",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877204",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877204",
+      "bn": null,
+      "id": "urn:barcode:33433101581191",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877204",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877204",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877204",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877204",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877204",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877204",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877204",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 34, no. 1 (Jan 2010)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877204",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877204",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877198",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877198",
+      "bn": null,
+      "id": "urn:barcode:33433101581142",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877198",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877198",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877198",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877198",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877198",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877198",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877198",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 33, no. 2 (Mar2009)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877198",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877198",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i28877199",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i28877199",
+      "bn": null,
+      "id": "urn:barcode:33433101581159",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i28877199",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i28877199",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i28877199",
+      "bn": null,
+      "id": "catalogItemType:4",
+      "la": "serial, loose",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i28877199",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i28877199",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i28877199",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i28877199",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124  v. 33, no. 3 (May 2009)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i28877199",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i28877199",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i17447371",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i17447371",
+      "bn": null,
+      "id": "urn:barcode:33433079115469",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i17447371",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i17447371",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i17447371",
+      "bn": null,
+      "id": "catalogItemType:3",
+      "la": "serial",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i17447371",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i17447371",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i17447371",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i17447371",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 26 (2002)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i17447371",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i17447371",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i17447372",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i17447372",
+      "bn": null,
+      "id": "urn:barcode:33433079115477",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i17447372",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i17447372",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i17447372",
+      "bn": null,
+      "id": "catalogItemType:3",
+      "la": "serial",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i17447372",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i17447372",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i17447372",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i17447372",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 27 (2003)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i17447372",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i17447372",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i17447369",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i17447369",
+      "bn": null,
+      "id": "urn:barcode:33433079115196",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i17447369",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i17447369",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i17447369",
+      "bn": null,
+      "id": "catalogItemType:3",
+      "la": "serial",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i17447369",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i17447369",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i17447369",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i17447369",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 28 (2004)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i17447369",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i17447369",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i17447370",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i17447370",
+      "bn": null,
+      "id": "urn:barcode:33433079115451",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i17447370",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i17447370",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i17447370",
+      "bn": null,
+      "id": "catalogItemType:3",
+      "la": "serial",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i17447370",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i17447370",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i17447370",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i17447370",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 25 (2001)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i17447370",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i17447370",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i16656945",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i16656945",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i16656945",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i13785893",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i13785893",
+      "bn": null,
+      "id": "urn:barcode:33433057526539",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i13785893",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i13785893",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i13785893",
+      "bn": null,
+      "id": "catalogItemType:3",
+      "la": "serial",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i13785893",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i13785893",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i13785893",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i13785893",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 24 (2000)",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i13785893",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i13785893",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i10005763",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i10005763",
+      "bn": null,
+      "id": "urn:barcode:33433005304468",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i10005763",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i10005763",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i10005763",
+      "bn": null,
+      "id": "catalogItemType:3",
+      "la": "serial",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i10005763",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i10005763",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i10005763",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i10005763",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 5-6 1982-83",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i10005763",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i10005763",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdfs:type"
+    },
+    {
+      "s": "i10005763",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i10005764",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i10005764",
+      "bn": null,
+      "id": "urn:barcode:33433005304476",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i10005764",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i10005764",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i10005764",
+      "bn": null,
+      "id": "catalogItemType:3",
+      "la": "serial",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i10005764",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i10005764",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i10005764",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i10005764",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 7 1984",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i10005764",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i10005764",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdfs:type"
+    },
+    {
+      "s": "i10005764",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i10005765",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i10005765",
+      "bn": null,
+      "id": "urn:barcode:33433005304484",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i10005765",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i10005765",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i10005765",
+      "bn": null,
+      "id": "catalogItemType:3",
+      "la": "serial",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i10005765",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i10005765",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i10005765",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i10005765",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 8 1985",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i10005765",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i10005765",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdfs:type"
+    },
+    {
+      "s": "i10005765",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i10005761",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i10005761",
+      "bn": null,
+      "id": "urn:barcode:33433005304443",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i10005761",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i10005761",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i10005761",
+      "bn": null,
+      "id": "catalogItemType:3",
+      "la": "serial",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i10005761",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i10005761",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i10005761",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i10005761",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 1-2 1978-79",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i10005761",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i10005761",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdfs:type"
+    },
+    {
+      "s": "i10005761",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    },
+    {
+      "s": "i10005762",
+      "bn": null,
+      "id": "status:a",
+      "la": "Available ",
+      "li": null,
+      "pr": "bf:status"
+    },
+    {
+      "s": "i10005762",
+      "bn": null,
+      "id": "urn:barcode:33433005304450",
+      "la": null,
+      "li": null,
+      "pr": "dcterms:identifier"
+    },
+    {
+      "s": "i10005762",
+      "bn": null,
+      "id": "accessMessage:2",
+      "la": "Request in advance",
+      "li": null,
+      "pr": "nypl:accessMessage"
+    },
+    {
+      "s": "i10005762",
+      "bn": null,
+      "id": "urn:bnum:b10011745",
+      "la": null,
+      "li": null,
+      "pr": "nypl:bnum"
+    },
+    {
+      "s": "i10005762",
+      "bn": null,
+      "id": "catalogItemType:3",
+      "la": "serial",
+      "li": null,
+      "pr": "nypl:catalogItemType"
+    },
+    {
+      "s": "i10005762",
+      "bn": null,
+      "id": "loc:rc2ma",
+      "la": "Offsite",
+      "li": null,
+      "pr": "nypl:holdingLocation"
+    },
+    {
+      "s": "i10005762",
+      "bn": null,
+      "id": "orgs:1000",
+      "la": "Stephen A. Schwarzman Building",
+      "li": null,
+      "pr": "nypl:owner"
+    },
+    {
+      "s": "i10005762",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "true",
+      "pr": "nypl:requestable"
+    },
+    {
+      "s": "i10005762",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "JFL 81-124 v. 3-4 1980-81",
+      "pr": "nypl:shelfMark"
+    },
+    {
+      "s": "i10005762",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "false",
+      "pr": "nypl:suppressed"
+    },
+    {
+      "s": "i10005762",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdfs:type"
+    },
+    {
+      "s": "i10005762",
+      "bn": null,
+      "id": "bf:Item",
+      "la": null,
+      "li": null,
+      "pr": "rdf:type"
+    }
+  ]
+}

--- a/test/data/sample-event-b10011745suppressed.json
+++ b/test/data/sample-event-b10011745suppressed.json
@@ -1,0 +1,20 @@
+{
+  "Records": [
+    {
+      "kinesis": {
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "s1",
+        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001",
+        "data": "JmIxMDAxMTc0NXN1cHByZXNzZWQGYmli",
+        "approximateArrivalTimestamp": 1428537600
+      },
+      "eventSource": "aws:kinesis",
+      "eventVersion": "1.0",
+      "eventID": "shardId-000000000000:00000000000000000000000000000000000000000000000000000001",
+      "eventName": "aws:kinesis:record",
+      "invokeIdentityArn": "arn:aws:iam::EXAMPLE",
+      "awsRegion": "us-east-1",
+      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument"
+    }
+  ]
+}

--- a/test/data/sample-event-b10610175-b10011745suppressed-bnonexistentbib.json
+++ b/test/data/sample-event-b10610175-b10011745suppressed-bnonexistentbib.json
@@ -1,0 +1,52 @@
+{
+  "Records": [
+    {
+      "kinesis": {
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "s1",
+        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001",
+        "data": "EmIxMDYxMDE3NQZiaWI=",
+        "approximateArrivalTimestamp": 1428537600
+      },
+      "eventSource": "aws:kinesis",
+      "eventVersion": "1.0",
+      "eventID": "shardId-000000000000:00000000000000000000000000000000000000000000000000000001",
+      "eventName": "aws:kinesis:record",
+      "invokeIdentityArn": "arn:aws:iam::EXAMPLE",
+      "awsRegion": "us-east-1",
+      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument"
+    },
+    {
+      "kinesis": {
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "s1",
+        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001",
+        "data": "JmIxMDAxMTc0NXN1cHByZXNzZWQGYmli",
+        "approximateArrivalTimestamp": 1428537600
+      },
+      "eventSource": "aws:kinesis",
+      "eventVersion": "1.0",
+      "eventID": "shardId-000000000000:00000000000000000000000000000000000000000000000000000001",
+      "eventName": "aws:kinesis:record",
+      "invokeIdentityArn": "arn:aws:iam::EXAMPLE",
+      "awsRegion": "us-east-1",
+      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument"
+    },
+    {
+      "kinesis": {
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "s1",
+        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001",
+        "data": "HmJub25leGlzdGVudGJpYgZiaWI=",
+        "approximateArrivalTimestamp": 1428537600
+      },
+      "eventSource": "aws:kinesis",
+      "eventVersion": "1.0",
+      "eventID": "shardId-000000000000:00000000000000000000000000000000000000000000000000000001",
+      "eventName": "aws:kinesis:record",
+      "invokeIdentityArn": "arn:aws:iam::EXAMPLE",
+      "awsRegion": "us-east-1",
+      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument"
+    }
+  ]
+}

--- a/test/data/sample-event-b10610175.json
+++ b/test/data/sample-event-b10610175.json
@@ -1,0 +1,20 @@
+{
+  "Records": [
+    {
+      "kinesis": {
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "s1",
+        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001",
+        "data": "EmIxMDYxMDE3NQZiaWI=",
+        "approximateArrivalTimestamp": 1428537600
+      },
+      "eventSource": "aws:kinesis",
+      "eventVersion": "1.0",
+      "eventID": "shardId-000000000000:00000000000000000000000000000000000000000000000000000001",
+      "eventName": "aws:kinesis:record",
+      "invokeIdentityArn": "arn:aws:iam::EXAMPLE",
+      "awsRegion": "us-east-1",
+      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument"
+    }
+  ]
+}

--- a/test/data/sample-event-bnonexistentbib.json
+++ b/test/data/sample-event-bnonexistentbib.json
@@ -1,0 +1,20 @@
+{
+  "Records": [
+    {
+      "kinesis": {
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "s1",
+        "sequenceNumber": "00000000000000000000000000000000000000000000000000000001",
+        "data": "HmJub25leGlzdGVudGJpYgZiaWI=",
+        "approximateArrivalTimestamp": 1428537600
+      },
+      "eventSource": "aws:kinesis",
+      "eventVersion": "1.0",
+      "eventID": "shardId-000000000000:00000000000000000000000000000000000000000000000000000001",
+      "eventName": "aws:kinesis:record",
+      "invokeIdentityArn": "arn:aws:iam::EXAMPLE",
+      "awsRegion": "us-east-1",
+      "eventSourceARN": "arn:aws:kinesis:us-east-1:224280085904:stream/IndexDocument"
+    }
+  ]
+}

--- a/test/document-stream-listener.test.js
+++ b/test/document-stream-listener.test.js
@@ -1,0 +1,121 @@
+/* global describe it beforeEach afterEach */
+
+const expect = require('chai').expect
+
+const fixtures = require('./fixtures')
+
+process.env.LOGLEVEL = process.env.LOGLEVEL || 'error'
+
+describe('DocumentStreamListener [main]', function () {
+  this.timeout(5000)
+
+  let DocumentStreamListener
+
+  beforeEach(() => {
+    fixtures.enable()
+    DocumentStreamListener = require('../document-stream-listener')
+  })
+
+  afterEach(fixtures.disable)
+
+  describe('#handler', function () {
+    it('should handle event single valid uri', function (done) {
+      const sampleEvent = require('./data/sample-event-b10610175.json')
+
+      const index = require('../lib/index')
+
+      DocumentStreamListener.handler(sampleEvent, {}, (err, result) => {
+        if (err) throw err
+
+        expect(result).to.be.a('string')
+        expect(result).to.equal('Wrote 1 docs(s)')
+        // Nothing should have been deleted:
+        expect(index.resources.delete.callCount).to.equal(0)
+        expect(index.resources.save.callCount).to.equal(1)
+        // Confirm the 2nd arg (`records`) is an array with a single record,
+        // which is the record we expect:
+        expect(index.resources.save.firstCall.args[1]).to.be.a('array')
+        expect(index.resources.save.firstCall.args[1]).to.have.lengthOf(1)
+        expect(index.resources.save.firstCall.args[1][0]).to.be.an('object')
+        expect(index.resources.save.firstCall.args[1][0].uri).to.equal('b10610175')
+
+        done()
+      })
+    })
+
+    it('should handle event with single suppressed uri', function (done) {
+      const sampleEvent = require('./data/sample-event-b10011745suppressed.json')
+
+      const index = require('../lib/index')
+
+      DocumentStreamListener.handler(sampleEvent, {}, (err, result) => {
+        if (err) throw err
+
+        expect(result).to.be.a('string')
+        expect(result).to.equal('Wrote 0 docs(s), suppressed 1 doc(s)')
+        // We expect no documents to have been saved:
+        expect(index.resources.save.callCount).to.equal(0)
+        // We expect a single delete due to suppression:
+        expect(index.resources.delete.callCount).to.equal(1)
+        // Confirm the 2nd arg (`id`) is the id we expect to delete:
+        expect(index.resources.delete.firstCall.args[1]).to.equal('b10011745suppressed')
+
+        done()
+      })
+    })
+
+    it('should handle event with single deleted uri', function (done) {
+      const sampleEvent = require('./data/sample-event-bnonexistentbib.json')
+
+      const index = require('../lib/index')
+
+      DocumentStreamListener.handler(sampleEvent, {}, (err, result) => {
+        if (err) throw err
+
+        expect(result).to.be.a('string')
+        expect(result).to.equal('Wrote 0 docs(s), deleted 1 doc(s)')
+        // We expect no documents to have been saved:
+        expect(index.resources.save.callCount).to.equal(0)
+        // We expect a single delete due to suppression:
+        expect(index.resources.delete.callCount).to.equal(1)
+        // Confirm the 2nd arg (`id`) is the id we expect to delete:
+        expect(index.resources.delete.firstCall.args[1]).to.equal('bnonexistentbib')
+
+        done()
+      })
+    })
+
+    it('should handle event with three uris: one valid, one suppressed, one invalid', function (done) {
+      const sampleEvent = require('./data/sample-event-b10610175-b10011745suppressed-bnonexistentbib.json')
+
+      const index = require('../lib/index')
+
+      DocumentStreamListener.handler(sampleEvent, {}, (err, result) => {
+        if (err) throw err
+
+        expect(result).to.be.a('string')
+        expect(result).to.equal('Wrote 1 docs(s), suppressed 1 doc(s), deleted 1 doc(s)')
+
+        // We expect only one document to be saved:
+        expect(index.resources.save.callCount).to.equal(1)
+        // Confirm the 2nd arg (`records`) is an array with a single record,
+        // which is the record we expect:
+        expect(index.resources.save.firstCall.args[1]).to.be.a('array')
+        expect(index.resources.save.firstCall.args[1]).to.have.lengthOf(1)
+        expect(index.resources.save.firstCall.args[1][0]).to.be.an('object')
+        expect(index.resources.save.firstCall.args[1][0].uri).to.equal('b10610175')
+
+        // Although reported differently, suppressions are implemented as a
+        // DELETE, so we expect two calls to DELETE:
+        expect(index.resources.delete.callCount).to.equal(2)
+        // Although they're ordered differently in the event, we expect non-
+        // existent bibs to be deleted first, and bibs deleted due to
+        // suppression to be deleted second:
+        expect(index.resources.delete.firstCall.args[1]).to.equal('bnonexistentbib')
+        expect(index.resources.delete.secondCall.args[1]).to.equal('b10011745suppressed')
+
+        done()
+      })
+    })
+  })
+})

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,0 +1,73 @@
+const sinon = require('sinon')
+const path = require('path')
+const fs = require('fs')
+const awsMock = require('aws-sdk-mock')
+
+const DiscoveryStoreModels = require('discovery-store-models')
+const { Bib } = DiscoveryStoreModels
+const kmsHelper = require('../lib/kms-helper')
+
+function bibFixturePath (id) {
+  return path.join(__dirname, `./data/${id}.json`)
+}
+
+let getBibByFixture = function (id) {
+  if (fs.existsSync(bibFixturePath(id))) {
+    let data = JSON.parse(fs.readFileSync(bibFixturePath(id)))
+    let bib = Bib.fromDbJsonResult(data)
+    return Promise.resolve(bib)
+  } else {
+    return Promise.reject(new Error(id + ' not found on disk'))
+  }
+}
+
+let getBibsByFixtures = function (ids) {
+  return Promise.all(
+    ids.map(
+      (id) => getBibByFixture(id).catch((e) => null)
+    )
+  )
+    // Filter out anything falsy (i.e. invalid bib id)
+    .then((bibs) => bibs.filter((bib) => bib))
+}
+
+let fakeIndexResourcesSave = function (indexName, resources) {
+  return Promise.resolve()
+}
+
+let fakeIndexResourcesDelete = function (indexName, id) {
+  return Promise.resolve()
+}
+
+let fakeKinesisPutRecords = function (params, callback) {
+  callback(null, { FailedRecordCount: 0, Records: params.Records })
+}
+
+function enable () {
+  const index = require('../lib/index')
+
+  process.env.NYPL_API_BASE_URL = 'https://platform.nypl.org/api/v0.1/'
+  process.env.NYPL_API_SCHEMA_URL = 'https://platform.nypl.org/api/v0.1/current-schemas/'
+
+  sinon.stub(Bib, 'byId').callsFake(getBibByFixture)
+  sinon.stub(Bib, 'byIds').callsFake(getBibsByFixtures)
+  sinon.stub(index.resources, 'save').callsFake(fakeIndexResourcesSave)
+  sinon.stub(index.resources, 'delete').callsFake(fakeIndexResourcesDelete)
+  awsMock.mock('Kinesis', 'putRecords', fakeKinesisPutRecords)
+  sinon.stub(kmsHelper, 'decryptDbCreds').callsFake(() => Promise.resolve('postgresql://user:pass@example.com:5432/mocked-sql-creds'))
+  sinon.stub(kmsHelper, 'decryptElasticCreds').callsFake(() => Promise.resolve('mocked-elastic-creds'))
+}
+
+function disable () {
+  const index = require('../lib/index')
+
+  Bib.byId.restore()
+  Bib.byIds.restore()
+  index.resources.save.restore()
+  index.resources.delete.restore()
+  awsMock.restore('Kinesis', 'putRecords')
+  kmsHelper.decryptDbCreds.restore()
+  kmsHelper.decryptElasticCreds.restore()
+}
+
+module.exports = { enable, disable }

--- a/test/resource-indexer.test.js
+++ b/test/resource-indexer.test.js
@@ -1,0 +1,114 @@
+/* global describe it beforeEach afterEach */
+
+const expect = require('chai').expect
+const _ = require('highland')
+
+const DiscoveryStoreModels = require('discovery-store-models')
+const { Bib } = DiscoveryStoreModels
+
+const fixtures = require('./fixtures')
+
+process.env.LOGLEVEL = process.env.LOGLEVEL || 'error'
+
+describe('ResourcesIndexer', function () {
+  this.timeout(5000)
+
+  let ResourceIndexer
+
+  beforeEach(() => {
+    fixtures.enable()
+    ResourceIndexer = require('../lib/resource-indexer')
+  })
+
+  afterEach(fixtures.disable)
+
+  describe('#processStreamOfBibs', function () {
+    it('should update two valid bibs', function () {
+      return Promise.all([
+        Bib.byId('b10681848'),
+        Bib.byId('b10011745')
+      ]).then((bibs) => {
+        return new Promise((resolve, reject) => {
+          let processingResult = null
+          ResourceIndexer.processStreamOfBibs(_(bibs), { notifyDocumentProcessed: false })
+            .map((ret) => {
+              // This is the thing we want to resolve, but let's just set it
+              // asside to resolve later
+              processingResult = ret
+            })
+            // Call .done to trigger stream processing
+            // Finish by resolving processingResult
+            .done(() => {
+              resolve(processingResult)
+            })
+        })
+      })
+      .then((processingResult) => {
+        expect(processingResult).to.be.a('object')
+        expect(processingResult.savedCount).to.equal(2)
+        expect(processingResult.savedUris).to.be.a('array')
+        expect(processingResult.savedUris).to.be.have.members(['b10681848', 'b10011745'])
+        expect(processingResult.suppressedCount).to.equal(0)
+      })
+    })
+
+    it('should update one valid bib, delete one invalid bib', function () {
+      return Promise.all([
+        Bib.byId('b10681848'),
+        Bib.byId('b10011745suppressed')
+      ]).then((bibs) => {
+        return new Promise((resolve, reject) => {
+          // Call .compact to Compact
+          bibs = _(bibs).compact()
+
+          let processingResult = null
+          ResourceIndexer.processStreamOfBibs(bibs)
+            .map((ret) => {
+              // This is the thing we want to resolve, but let's just set it
+              // asside to resolve later
+              processingResult = ret
+            })
+            // Call .done to trigger stream processing
+            // Finish by resolving processingResult
+            .done(() => {
+              resolve(processingResult)
+            })
+        })
+      })
+      .then((processingResult) => {
+        expect(processingResult).to.be.a('object')
+        expect(processingResult.savedCount).to.equal(1)
+        expect(processingResult.savedUris).to.be.have.members(['b10681848'])
+        expect(processingResult.suppressedCount).to.equal(1)
+        expect(processingResult.suppressedUris).to.have.members(['b10011745suppressed'])
+      })
+    })
+  })
+
+  describe('processArrayOfBibUris', function () {
+    it('should update one valid bib, suppress one suppressed bib, delete one invalid bib', function () {
+      const index = require('../lib/index')
+
+      return ResourceIndexer.processArrayOfBibUris(['b10610175', 'b10011745suppressed', 'bnonexistentbib'])
+        .then((result) => {
+          // We expect only one document to be saved:
+          expect(index.resources.save.callCount).to.equal(1)
+          // Confirm the 2nd arg (`records`) is an array with a single record,
+          // which is the record we expect:
+          expect(index.resources.save.firstCall.args[1]).to.be.a('array')
+          expect(index.resources.save.firstCall.args[1]).to.have.lengthOf(1)
+          expect(index.resources.save.firstCall.args[1][0]).to.be.an('object')
+          expect(index.resources.save.firstCall.args[1][0].uri).to.equal('b10610175')
+
+          // Although reported differently, suppressions are implemented as a
+          // DELETE, so we expect two calls to DELETE:
+          expect(index.resources.delete.callCount).to.equal(2)
+          // Although they're ordered differently in the event, we expect non-
+          // existent bibs to be deleted first, and bibs deleted due to
+          // suppression to be deleted second:
+          expect(index.resources.delete.firstCall.args[1]).to.equal('bnonexistentbib')
+          expect(index.resources.delete.secondCall.args[1]).to.equal('b10011745suppressed')
+        })
+    })
+  })
+})


### PR DESCRIPTION
This fixes a bug where a record that fails to be returned from the
DiscoveryStore doesn't result in the related document being deleted.
Previously, SQL lookups that failed were quietly ignored because the id
was assumed to be invalid (i.e. testing). It appears that legitimate
sierra deletions leave a set of statements in the DiscoveryStore that
isn't sufficient for retrieval. (In particular, upon deletion, the
'rdfs:type' statement is deleted because that statement can't be derived
from a `"deleted": true` record. When the DiscoveryApiIndexer
subsequently fetches statements for that record, the query used
*requires* 'rdfs:type', which produces a lookup failure.)

The solution here is to treat all lookup failures as occassions to
delete the corresponding ES document - even if this means we're sending
DELETE queryies against document ids that don't exist (i.e. invalid ids,
ids used for testing). Any id that fails to yeild a minimal set of
statements from the DiscoveryStore should not have a corresponding
document in ES.

This also adds tests covering suppressions and deletions, which were not
previously tested. This required restructuring lib/resource-indexer and
document-stream-listener to be more unit testable - and hopefully clearer.