### PR TITLE
Disaggregate subjects

### DIFF
--- a/lib/es-serializer.js
+++ b/lib/es-serializer.js
@@ -217,6 +217,7 @@ class ResourceSerializer extends EsSerializer {
       'Publication statement',
       'Publisher literal',
       'Series statement',
+      'Subject literal',
       'Title',
       'Title display',
       'Uniform title'
@@ -232,8 +233,8 @@ class ResourceSerializer extends EsSerializer {
 
     bibFieldMapper.getMapping('Subject literal', (spec) => {
       this.object.each(spec.pred, (triple) => {
-        utils.subtriples(triple).forEach((subtriple) => {
-          this.addStatement(spec.jsonLdKey, subtriple.object_literal)
+        utils.explodedSubjectLiterals(triple).forEach((explodedSubjectLiteral) => {
+          this.addStatement('subjectLiteral_exploded', explodedSubjectLiteral)
         })
       })
     })

--- a/lib/es-serializer.js
+++ b/lib/es-serializer.js
@@ -217,19 +217,12 @@ class ResourceSerializer extends EsSerializer {
       'Publication statement',
       'Publisher literal',
       'Series statement',
-      // 'Subject literal',
       'Title',
       'Title display',
       'Uniform title'
     ].forEach((name) => {
       bibFieldMapper.getMapping(name, (spec) => {
-        // if (spec.pred === 'dc:subject') {
-          // console.log(226, 'this ', this, 'spec ', spec)
-        // }
         this.object.each(spec.pred, (triple) => {
-          // if (spec.pred === 'dc:subject') {
-            // console.log('triple ', triple)
-          // }
           this.addStatement(spec.jsonLdKey, triple.object_literal)
         })
       })

--- a/lib/es-serializer.js
+++ b/lib/es-serializer.js
@@ -1,4 +1,5 @@
 'use strict'
+const utils = require('./utils')
 
 const bibFieldMapper = require('./field-mapper')('bib')
 const itemFieldMapper = require('./field-mapper')('item')
@@ -216,14 +217,30 @@ class ResourceSerializer extends EsSerializer {
       'Publication statement',
       'Publisher literal',
       'Series statement',
-      'Subject literal',
+      // 'Subject literal',
       'Title',
       'Title display',
       'Uniform title'
     ].forEach((name) => {
       bibFieldMapper.getMapping(name, (spec) => {
+        // if (spec.pred === 'dc:subject') {
+          // console.log(226, 'this ', this, 'spec ', spec)
+        // }
         this.object.each(spec.pred, (triple) => {
+          // if (spec.pred === 'dc:subject') {
+            // console.log('triple ', triple)
+          // }
           this.addStatement(spec.jsonLdKey, triple.object_literal)
+        })
+      })
+    })
+
+    // Add disaggregated subjects
+
+    bibFieldMapper.getMapping('Subject literal', (spec) => {
+      this.object.each(spec.pred, (triple) => {
+        utils.subtriples(triple).forEach((subtriple) => {
+          this.addStatement(spec.jsonLdKey, subtriple.object_literal)
         })
       })
     })

--- a/lib/index.js
+++ b/lib/index.js
@@ -220,6 +220,7 @@ const resourcesProperties = {
     }
   },
   subjectLiteral: mappingTemplates.fulltextWithRawFolded,
+  subjectLiteral_exploded: mappingTemplates.exactString,
   supplementaryContent: {
     type: 'object',
     properties: {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -63,12 +63,12 @@ exports.deepFilterByKey = function (obj, cb) {
  * instance of -- and otherwise S is the same as T
  */
 
- exports.subtriples = function (triple) {
-   const subSubjects = triple.object_literal.slice(0,-1).split(" -- ") //should we worry about other kinds of whitespace?
-   const subTriples = [ Object.assign({}, triple, { object_literal: subSubjects.shift() }) ]
-   return subSubjects.reduce((acc, subSubject) => {
-      const lastSubject = acc[acc.length - 1].object_literal
-      acc.push(Object.assign({}, triple, { object_literal: lastSubject + ' -- ' + subSubject }))
-      return acc
-   }, subTriples)
- }
+exports.subtriples = function (triple) {
+  const subSubjects = triple.object_literal.slice(0, -1).split(' -- ') // should we worry about other kinds of whitespace?
+  const subTriples = [ Object.assign({}, triple, { object_literal: subSubjects.shift() }) ]
+  return subSubjects.reduce((acc, subSubject) => {
+    const lastSubject = acc[acc.length - 1].object_literal
+    acc.push(Object.assign({}, triple, { object_literal: lastSubject + ' -- ' + subSubject }))
+    return acc
+  }, subTriples)
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -61,13 +61,8 @@ exports.deepFilterByKey = function (obj, cb) {
  * Given a triple returns a collection of all subjects that occur as initial ' -- '-delimited substrings of the subject
  * recorded in the triple's object_literal property
  */
-
 exports.explodedSubjectLiterals = function (triple) {
   const subject = triple.object_literal.slice(-1) === '.' ? triple.object_literal.slice(0, -1) : triple.object_literal
   const componentSubjects = subject.split(' -- ')
-  const explodedSubjects = [componentSubjects.shift()]
-  while (componentSubjects.length !== 0) {
-    explodedSubjects.push(explodedSubjects.slice(-1)[0] + ' -- ' + componentSubjects.shift())
-  }
-  return explodedSubjects.map((subject) => subject.trimRight())
+  return componentSubjects.map((subject, i) => componentSubjects.slice(0, i + 1).join(' -- ').trimRight())
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -65,10 +65,10 @@ exports.deepFilterByKey = function (obj, cb) {
 
  exports.subtriples = function (triple) {
    const subSubjects = triple.object_literal.slice(0,-1).split(" -- ") //should we worry about other kinds of whitespace?
-   const subTriples = [ Object.assign(triple), { object_literal: subSubjects.shift() } ]
+   const subTriples = [ Object.assign(triple, { object_literal: subSubjects.shift() }) ]
    return subSubjects.reduce((acc, subSubject) => {
       const lastSubject = acc[acc.length - 1].object_literal
-      acc.push(Object.assign(triple), { object_literal: lastSubject + ' -- ' + subSubject })
-      acc
+      acc.push(Object.assign(triple, { object_literal: lastSubject + ' -- ' + subSubject }))
+      return acc
    }, subTriples)
  }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,5 +64,5 @@ exports.deepFilterByKey = function (obj, cb) {
 exports.explodedSubjectLiterals = function (triple) {
   const subject = triple.object_literal.slice(-1) === '.' ? triple.object_literal.slice(0, -1) : triple.object_literal
   const componentSubjects = subject.split(' -- ')
-  return componentSubjects.map((subject, i) => componentSubjects.slice(0, i + 1).join(' -- ').trimEnd())
+  return componentSubjects.map((subject, i) => componentSubjects.slice(0, i + 1).join(' -- ').trim())
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,5 +64,5 @@ exports.deepFilterByKey = function (obj, cb) {
 exports.explodedSubjectLiterals = function (triple) {
   const subject = triple.object_literal.slice(-1) === '.' ? triple.object_literal.slice(0, -1) : triple.object_literal
   const componentSubjects = subject.split(' -- ')
-  return componentSubjects.map((subject, i) => componentSubjects.slice(0, i + 1).join(' -- ').trimRight())
+  return componentSubjects.map((subject, i) => componentSubjects.slice(0, i + 1).join(' -- ').trimEnd())
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,3 +56,19 @@ exports.deepFilterByKey = function (obj, cb) {
     return clean
   }, {})
 }
+
+/**
+ * Given a triple returns a collection of all subtriples, where S is a subtriple
+ * of T if S.object_literal is an initial substring of T.object_literal up to an
+ * instance of -- and otherwise S is the same as T
+ */
+
+ exports.subtriples = function (triple) {
+   const subSubjects = triple.object_literal.slice(0,-1).split(" -- ") //should we worry about other kinds of whitespace?
+   const subTriples = [ Object.assign(triple), { object_literal: subSubjects.shift() } ]
+   return subSubjects.reduce((acc, subSubject) => {
+      const lastSubject = acc[acc.length - 1].object_literal
+      acc.push(Object.assign(triple), { object_literal: lastSubject + ' -- ' + subSubject })
+      acc
+   }, subTriples)
+ }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -65,10 +65,12 @@ exports.deepFilterByKey = function (obj, cb) {
 
  exports.subtriples = function (triple) {
    const subSubjects = triple.object_literal.slice(0,-1).split(" -- ") //should we worry about other kinds of whitespace?
-   const subTriples = [ Object.assign(triple, { object_literal: subSubjects.shift() }) ]
+   const subTriples = [ Object.assign({}, triple, { object_literal: subSubjects.shift() }) ]
    return subSubjects.reduce((acc, subSubject) => {
       const lastSubject = acc[acc.length - 1].object_literal
-      acc.push(Object.assign(triple, { object_literal: lastSubject + ' -- ' + subSubject }))
+      // console.log(lastSubject)
+      acc.push(Object.assign({}, triple, { object_literal: lastSubject + ' -- ' + subSubject }))
+      // console.log(acc)
       return acc
    }, subTriples)
  }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -58,22 +58,6 @@ exports.deepFilterByKey = function (obj, cb) {
 }
 
 /**
- * Given a triple returns a collection of all subtriples, where S is a subtriple
- * of T if S.object_literal is an initial substring of T.object_literal up to an
- * instance of -- and otherwise S is the same as T
- */
-
-exports.subtriples = function (triple) {
-  const subSubjects = triple.object_literal.slice(0, -1).split(' -- ') // should we worry about other kinds of whitespace?
-  const subTriples = [ Object.assign({}, triple, { object_literal: subSubjects.shift() }) ]
-  return subSubjects.reduce((acc, subSubject) => {
-    const lastSubject = acc[acc.length - 1].object_literal
-    acc.push(Object.assign({}, triple, { object_literal: lastSubject + ' -- ' + subSubject }))
-    return acc
-  }, subTriples)
-}
-
-/**
  * Given a triple returns a collection of all subjects that occur as initial ' -- '-delimited substrings of the subject
  * recorded in the triple's object_literal property
  */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -68,9 +68,7 @@ exports.deepFilterByKey = function (obj, cb) {
    const subTriples = [ Object.assign({}, triple, { object_literal: subSubjects.shift() }) ]
    return subSubjects.reduce((acc, subSubject) => {
       const lastSubject = acc[acc.length - 1].object_literal
-      // console.log(lastSubject)
       acc.push(Object.assign({}, triple, { object_literal: lastSubject + ' -- ' + subSubject }))
-      // console.log(acc)
       return acc
    }, subTriples)
  }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -72,3 +72,18 @@ exports.subtriples = function (triple) {
     return acc
   }, subTriples)
 }
+
+/**
+ * Given a triple returns a collection of all subjects that occur as initial ' -- '-delimited substrings of the subject
+ * recorded in the triple's object_literal property
+ */
+
+exports.explodedSubjectLiterals = function (triple) {
+  const subject = triple.object_literal.slice(-1) === '.' ? triple.object_literal.slice(0, -1) : triple.object_literal
+  const componentSubjects = subject.split(' -- ')
+  const explodedSubjects = [componentSubjects.shift()]
+  while (componentSubjects.length !== 0) {
+    explodedSubjects.push(explodedSubjects.slice(-1)[0] + ' -- ' + componentSubjects.shift())
+  }
+  return explodedSubjects.map((subject) => subject.trimRight())
+}

--- a/test/bib-serializations-test.js
+++ b/test/bib-serializations-test.js
@@ -68,8 +68,8 @@ describe('Bib Serializations', function () {
     it('should have all subject literals', function () {
       return Bib.byId('b11253008').then((bib) => {
         return ResourceSerializer.serialize(bib).then((serialized) => {
-          assert.equal(serialized.subjectLiteral[0], 'African American fashion designers')
-          assert.equal(serialized.subjectLiteral[1], 'African American fashion designers -- Interviews')
+          assert.equal(serialized.subjectLiteral_exploded[0], 'African American fashion designers')
+          assert.equal(serialized.subjectLiteral_exploded[1], 'African American fashion designers -- Interviews')
         })
       })
     })

--- a/test/bib-serializations-test.js
+++ b/test/bib-serializations-test.js
@@ -65,10 +65,11 @@ describe('Bib Serializations', function () {
       })
     })
 
-    it('should have subject literal', function () {
+    it('should have all subject literals', function () {
       return Bib.byId('b11253008').then((bib) => {
         return ResourceSerializer.serialize(bib).then((serialized) => {
-          assert.equal(serialized.subjectLiteral[0], 'African American fashion designers -- Interviews.')
+          assert.equal(serialized.subjectLiteral[0], 'African American fashion designers')
+          assert.equal(serialized.subjectLiteral[1], 'African American fashion designers -- Interviews')
         })
       })
     })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -54,4 +54,38 @@ describe('Utils', function () {
       assert(!h.c.deepObject.deeperObject)
     })
   })
+
+  describe('subtriples', function () {
+    it('should create a list of triples with all the higher-level subjects represented', function () {
+      const testTriple = {
+        subject_id: undefined,
+        predicate: 'dc:subject',
+        object_id: null,
+        object_type: null,
+        object_literal: 'Arabian Peninsula -- Religion -- Ancient History.',
+        object_label: null
+      }
+
+      const subtriples = utils.subtriples(testTriple)
+      assert.equal(subtriples.length, 3)
+      assert.equal(subtriples[0].object_literal, 'Arabian Peninsula')
+      assert.equal(subtriples[1].object_literal, 'Arabian Peninsula -- Religion')
+      assert.equal(subtriples[2].object_literal, 'Arabian Peninsula -- Religion -- Ancient History')
+    })
+
+    it('should not break when given a triple with no higher-level subjects', function () {
+      const testTriple = {
+        subject_id: undefined,
+        predicate: 'dc:subject',
+        object_id: null,
+        object_type: null,
+        object_literal: 'Arabian Peninsula.',
+        object_label: null
+      }
+
+      const subtriples = utils.subtriples(testTriple)
+      assert.equal(subtriples.length, 1)
+      assert.equal(subtriples[0].object_literal, 'Arabian Peninsula')
+    })
+  })
 })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -88,4 +88,38 @@ describe('Utils', function () {
       assert.equal(subtriples[0].object_literal, 'Arabian Peninsula')
     })
   })
+
+  describe('explodedSubjectLiterals', function () {
+    it('should create a list of triples with all the higher-level subjects represented', function () {
+      const testTriple = {
+        subject_id: undefined,
+        predicate: 'dc:subject',
+        object_id: null,
+        object_type: null,
+        object_literal: 'Arabian Peninsula -- Religion -- Ancient History.',
+        object_label: null
+      }
+
+      const explodedSubjectLiterals = utils.explodedSubjectLiterals(testTriple)
+      assert.equal(explodedSubjectLiterals.length, 3)
+      assert.equal(explodedSubjectLiterals[0], 'Arabian Peninsula')
+      assert.equal(explodedSubjectLiterals[1], 'Arabian Peninsula -- Religion')
+      assert.equal(explodedSubjectLiterals[2], 'Arabian Peninsula -- Religion -- Ancient History')
+    })
+
+    it('should not break when given a triple with no higher-level subjects', function () {
+      const testTriple = {
+        subject_id: undefined,
+        predicate: 'dc:subject',
+        object_id: null,
+        object_type: null,
+        object_literal: 'Arabian Peninsula.',
+        object_label: null
+      }
+
+      const explodedSubjectLiterals = utils.explodedSubjectLiterals(testTriple)
+      assert.equal(explodedSubjectLiterals.length, 1)
+      assert.equal(explodedSubjectLiterals[0], 'Arabian Peninsula')
+    })
+  })
 })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -55,40 +55,6 @@ describe('Utils', function () {
     })
   })
 
-  describe('subtriples', function () {
-    it('should create a list of triples with all the higher-level subjects represented', function () {
-      const testTriple = {
-        subject_id: undefined,
-        predicate: 'dc:subject',
-        object_id: null,
-        object_type: null,
-        object_literal: 'Arabian Peninsula -- Religion -- Ancient History.',
-        object_label: null
-      }
-
-      const subtriples = utils.subtriples(testTriple)
-      assert.equal(subtriples.length, 3)
-      assert.equal(subtriples[0].object_literal, 'Arabian Peninsula')
-      assert.equal(subtriples[1].object_literal, 'Arabian Peninsula -- Religion')
-      assert.equal(subtriples[2].object_literal, 'Arabian Peninsula -- Religion -- Ancient History')
-    })
-
-    it('should not break when given a triple with no higher-level subjects', function () {
-      const testTriple = {
-        subject_id: undefined,
-        predicate: 'dc:subject',
-        object_id: null,
-        object_type: null,
-        object_literal: 'Arabian Peninsula.',
-        object_label: null
-      }
-
-      const subtriples = utils.subtriples(testTriple)
-      assert.equal(subtriples.length, 1)
-      assert.equal(subtriples[0].object_literal, 'Arabian Peninsula')
-    })
-  })
-
   describe('explodedSubjectLiterals', function () {
     it('should create a list of triples with all the higher-level subjects represented', function () {
       const testTriple = {


### PR DESCRIPTION
This branch changes the way we serialize subjects. Wherever we have subjects with sub-subjects delimited by ` -- `, we will know serialize all the sub-subjects separately.

Some questions for the reviewer:
1) Should we be concerned about variable whitespace before/after the  `--`? I am assuming for the moment that this isn't an issue.
2) Is the comment describing the function utils.subtriples readable? Any suggestions for how to improve the clarity of this comment?
3) This function will strip the period from the subjects. Do we want to change this?
4) This PR merges into master. Is that the correct workflow for this repo?
5) Are there any other tests we should add?