### PR TITLE
SCC-2207 Add Holding to ElasticSearch index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ deploy:
    script: ./scripts/travis-deploy.sh $TRAVIS_BRANCH
    on:
      all_branches: true
-     condition: $TRAVIS_BRANCH =~ ^(development|qa|production)$
+     condition: $TRAVIS_BRANCH =~ ^(qa|production)$
 after_deploy: echo "Successfully executed deploy trigger for $TRAVIS_BRANCH"
 env:
   global:

--- a/lib/field-mapper.js
+++ b/lib/field-mapper.js
@@ -77,7 +77,7 @@ var amendMappingsBasedOnNyplSource = (data, nyplSource) => {
  * require('./field-mapper')('item', 'sierra-nypl')
  */
 function buildMapper (type, nyplSource) {
-  if (['bib', 'item'].indexOf(type) >= 0) {
+  if (['bib', 'item', 'holding'].indexOf(type) >= 0) {
     let data = requireRemote(`https://raw.githubusercontent.com/NYPL/nypl-core/${process.env.NYPL_CORE_VERSION || 'master'}/mappings/recap-discovery/field-mapping-${type}.json`)
 
     // If nyplSource given, trim mappings to agree with it:

--- a/lib/index.js
+++ b/lib/index.js
@@ -500,7 +500,7 @@ function mappingsDiff (localMapping, remoteMapping) {
     .reduce((report, property) => {
       // If it's nested, recurse:
       if (localMapping[property].type === 'nested') {
-        let nestedReport = mappingsDiff(localMapping[property].properties, remoteMapping[property].properties)
+        let nestedReport = mappingsDiff(localMapping[property].properties, remoteMapping[property] ? remoteMapping[property].properties : {})
         return Object.keys(nestedReport).reduce((newReport, key) => {
           newReport[key] = newReport[key].concat(nestedReport[key].map((instance) => {
             return Object.assign({}, instance, { property: `${property}.${instance.property}` })

--- a/lib/index.js
+++ b/lib/index.js
@@ -115,6 +115,42 @@ const resourcesProperties = {
   extent: mappingTemplates.exactString,
   formerTitle: mappingTemplates.fulltextFolded,
   genreForm: mappingTemplates.fulltextWithRawFolded,
+  holdings: {
+    type: 'nested',
+    properties: {
+      checkInBoxes: {
+        type: 'nested',
+        properties: {
+          copies: mappingTemplates.number,
+          coverage: mappingTemplates.exactString,
+          position: mappingTemplates.number,
+          shelfMark: mappingTemplates.exactStringNotIndexed,
+          status: mappingTemplates.exactString,
+          type: mappingTemplates.exactString
+        }
+      },
+      format: mappingTemplates.exactString,
+      holdingStatement: mappingTemplates.exactString,
+      identifier: mappingTemplates.exactString,
+      identifierV2: {
+        properties: {
+          value: mappingTemplates.exactString,
+          type: mappingTemplates.exactString,
+          identifierStatus: mappingTemplates.exactString
+        }
+      },
+      location: {
+        properties: {
+          code: mappingTemplates.exactString,
+          label: mappingTemplates.exactString
+        }
+      },
+      notes: mappingTemplates.exactString,
+      physicalLocation: mappingTemplates.exactStringNotIndexed,
+      shelfMark: mappingTemplates.exactString,
+      uri: mappingTemplates.exactString
+    }
+  },
   idIsbn: mappingTemplates.exactString,
   idIssn: mappingTemplates.exactString,
   idLcc: mappingTemplates.exactString,
@@ -149,6 +185,7 @@ const resourcesProperties = {
           label: { type: 'keyword', index: false }
         }
       },
+      enumerationChronology: mappingTemplates.exactString,
       holdingLocation: mappingTemplates.entity,
       holdingLocation_packed: mappingTemplates.packed,
       identifier: mappingTemplates.exactString,
@@ -162,6 +199,7 @@ const resourcesProperties = {
       location: mappingTemplates.entity,
       owner: mappingTemplates.entity,
       owner_packed: mappingTemplates.packed,
+      physicalLocation: mappingTemplates.exactString,
       requestable: mappingTemplates.boolean,
       shelfMark: {
         // We're indexing this as text only so that it can be used in query_string

--- a/lib/index.js
+++ b/lib/index.js
@@ -131,8 +131,7 @@ const resourcesProperties = {
       },
       format: mappingTemplates.exactString,
       holdingStatement: mappingTemplates.exactString,
-      identifier: mappingTemplates.exactString,
-      identifierV2: {
+      identifier: {
         properties: {
           value: mappingTemplates.exactString,
           type: mappingTemplates.exactString,

--- a/lib/resource-indexer.js
+++ b/lib/resource-indexer.js
@@ -5,7 +5,7 @@ const log = require('loglevel')
 const NyplStreamsClient = require('@nypl/nypl-streams-client')
 
 const index = require('./index')
-const ResourceSerializer = require('./es-serializer').ResourceSerializer
+const ResourceSerializer = require('./serializers/resource-serializer')
 
 const OUTGOING_SCHEMA_NAME = process.env['OUTGOING_SCHEMA_NAME'] || 'IndexDocumentProcessed'
 const OUTGOING_STREAM_NAME = process.env['OUTGOING_STREAM_NAME'] || 'IndexDocumentProcessed'

--- a/lib/serializers/es-serializer.js
+++ b/lib/serializers/es-serializer.js
@@ -1,0 +1,43 @@
+'use strict'
+
+class EsSerializer {
+  constructor (object) {
+    this.object = object
+    this.statements = {}
+  }
+
+  addStatement (key, value, label, opts = {}) {
+    opts = Object.assign({
+      // By default, add a packed field if label is set
+      addPackedField: label
+    }, opts)
+
+    if (this.hasStatement(key, value)) return this
+
+    var _val = value
+    if (label) _val = { id: value, label: label }
+
+    if (!this.statements[key]) this.statements[key] = [_val]
+    else this.statements[key].push(_val)
+
+    if (opts.addPackedField) {
+      this.addPackedStatement(key, value, label)
+    }
+    return this
+  }
+
+  hasStatement (key, value) {
+    return this.statements[key] &&
+      (
+        ((typeof this.statements[key]) === 'object' && this.statements[key].indexOf(value) >= 0) ||
+        ((typeof this.statements[key]) !== 'object' && this.statements[key] === value)
+      )
+  }
+
+  addPackedStatement (key, value, label) {
+    var packedVal = [value, label].join('||')
+    return this.addStatement(`${key}_packed`, packedVal)
+  }
+}
+
+module.exports = EsSerializer

--- a/lib/serializers/resource-holding-serializer.js
+++ b/lib/serializers/resource-holding-serializer.js
@@ -6,6 +6,7 @@ const EsSerializer = require('./es-serializer')
 
 class ResourceHoldingSerializer extends EsSerializer {
   serialize () {
+    log.debug(`Serializing Holding ${this.object.uri}`)
     const fieldMapping = holdingFieldMapper
 
     // Block suppressed and deleted holdings

--- a/lib/serializers/resource-holding-serializer.js
+++ b/lib/serializers/resource-holding-serializer.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const holdingFieldMapper = require('./../field-mapper')('holding')
+const log = require('loglevel')
+const EsSerializer = require('./es-serializer')
+
+class ResourceHoldingSerializer extends EsSerializer {
+  serialize () {
+    const fieldMapping = holdingFieldMapper
+
+    // Block suppressed and deleted holdings
+    if (this.object.literal(fieldMapping.predicateFor('Suppressed')) === 'true') {
+      log.info('Suppressed/Deleted records should not be serialized')
+      return null
+    }
+
+    this.statements.uri = this.object.uri
+
+    // Add Basic literal fields
+    ; [ 'Format', 'Note', 'Physical Location', 'Holding Statement' ].forEach((name) => {
+      holdingFieldMapper.getMapping(name, (spec) => {
+        this.object.each(spec.pred, (triple) => {
+          this.addStatement(spec.jsonLdKey, triple.object_literal)
+        })
+      })
+    })
+
+    // Add call number/shelfMark as identifiers
+    holdingFieldMapper.getMapping('Call Number', (spec) => {
+      this.object.each(spec.pred, (triple) => {
+        this.addStatement(spec.jsonLdKey, triple.object_literal)
+        this.addStatement('identifierV2', { value: triple.object_literal, type: 'bf:shelfMark' })
+      })
+    })
+
+    // Add fields that are labels, right now this is just location
+    holdingFieldMapper.getMapping('Location', (spec) => {
+      this.object.each(spec.pred, (triple) => {
+        this.addStatement(spec.jsonLdKey, { label: triple.object_label, code: triple.object_id })
+      })
+    })
+
+    // Add Check-In Cards which are represented as blank nodes
+    holdingFieldMapper.getMapping('Check In Box', (spec) => {
+      this.object.blankNodes(spec.pred, (blankNode) => {
+        this.addStatement(spec.jsonLdKey, {
+          type: 'nypl:CheckInBox',
+          coverage: blankNode.literal('dcterms:coverage'),
+          status: blankNode.literal('bf:status'),
+          copies: blankNode.literal('bf:count'),
+          position: blankNode.literal('bf:part')
+        })
+      })
+    })
+
+    return this.statements
+  }
+}
+
+ResourceHoldingSerializer.serialize = (item) => (new ResourceHoldingSerializer(item)).serialize()
+
+module.exports = ResourceHoldingSerializer

--- a/lib/serializers/resource-holding-serializer.js
+++ b/lib/serializers/resource-holding-serializer.js
@@ -29,7 +29,7 @@ class ResourceHoldingSerializer extends EsSerializer {
     holdingFieldMapper.getMapping('Call Number', (spec) => {
       this.object.each(spec.pred, (triple) => {
         this.addStatement(spec.jsonLdKey, triple.object_literal)
-        this.addStatement('identifierV2', { value: triple.object_literal, type: 'bf:shelfMark' })
+        this.addStatement('identifier', { value: triple.object_literal, type: 'bf:shelfMark' })
       })
     })
 

--- a/lib/serializers/resource-item-serializer.js
+++ b/lib/serializers/resource-item-serializer.js
@@ -1,0 +1,166 @@
+'use strict'
+
+const itemFieldMapper = require('./../field-mapper')('item')
+const bibFieldMapper = require('./../field-mapper')('bib')
+const log = require('loglevel')
+const EsSerializer = require('./es-serializer')
+
+class ResourceItemSerializer extends EsSerializer {
+  serialize () {
+    const fieldMapping = itemFieldMapper
+    // If Item is suppressed, fail serialization
+    var suppressed = this.object.literal(fieldMapping.predicateFor('Suppressed')) === 'true'
+    if (suppressed) {
+      log.info('Refusing to serialize suppressed ' + this.object.uri)
+      return null
+    }
+
+    this.statements['uri'] = this.object.uri
+
+    // Add entities:
+    ; [
+      'Availability',
+      'Content owner',
+      'Catalog item type',
+      'Holding location'
+    ].forEach((name) => {
+      itemFieldMapper.getMapping(name, (spec) => {
+        this.object.each(spec.pred, (triple) => {
+          this.addStatement(spec.jsonLdKey, triple.object_id, triple.object_label)
+        })
+      })
+    })
+
+    itemFieldMapper.getMapping('Call number', (spec) => {
+      this.object.each(spec.pred, (triple) => {
+        this.addStatement(spec.jsonLdKey, triple.object_literal)
+
+        this.addStatement('identifierV2', { value: triple.object_literal, type: 'bf:ShelfMark' })
+      })
+    })
+
+    // Add call number components
+    ; [ 'Physical Location', 'Enumeration Chronology' ].forEach((name) => {
+      itemFieldMapper.getMapping(name, (spec) => {
+        this.addStatement(spec.jsonLdKey, spec.object_literal)
+      })
+    })
+
+    // Add identifiers
+    const identifierPred = fieldMapping.predicateFor('Identifier')
+    const identifierValues = this.object.statements(identifierPred)
+      .map(parseIdentifierFromStatement)
+
+    // Index identifier entity to 'identifierV2':
+    identifierValues.forEach((identifier) => {
+      this.addStatement('identifier', identifier.urnStyle)
+
+      if (identifier.entityStyle) {
+        this.addStatement('identifierV2', identifier.entityStyle)
+
+        // Add special json-ld key based on type:
+        switch (identifier.entityStyle.type) {
+          case 'bf:Barcode':
+            this.addStatement('idBarcode', identifier.entityStyle.value)
+            break
+        }
+      }
+    })
+
+    // Note this comes from bib mapping because that's where it's extracted from:
+    bibFieldMapper.getMapping('Electronic location', (spec) => {
+      this.object.each(spec.pred, (triple) => {
+        this.addStatement(spec.jsonLdKey, { url: triple.object_literal, label: triple.object_label })
+      })
+      // TODO This is a temporary hack to fix fact most resources encoded using this incorrect pred:
+      // Remove this once statements remapped to 'bf:electronicLocator'
+      this.object.each('nypl:electronicLocator', (triple) => {
+        this.addStatement(spec.jsonLdKey, { url: triple.object_literal, label: triple.object_label })
+      })
+    })
+
+    var requestablePred = fieldMapping.predicateFor('Requestable')
+    if (this.object.has(requestablePred)) {
+      this.object.each(requestablePred, (triple) => {
+        this.addStatement('requestable', triple.object_literal === 'true')
+      })
+    }
+
+    var accessMessagePred = fieldMapping.predicateFor('Access message')
+    if (this.object.has(accessMessagePred)) {
+      this.object.each(accessMessagePred, (triple) => {
+        this.addStatement('accessMessage', triple.object_id, triple.object_label)
+      })
+    }
+
+    return this.statements
+  }
+}
+
+/**
+ * Given a dcterms:identifier statement record, returns a plainobject
+ * containing:
+ *   entityStyle: a plainobject with `type` and `value` properties
+ *                suitable for indexing in identifierV2
+ *   urnStyle:    a string built using legacy "urn:[prefix]:[value]"
+ *
+ * TODO This is mostly temporary to ease transition to entity style
+ */
+function parseIdentifierFromStatement (statement) {
+  const urnPrefixMap = {
+    barcode: 'bf:Barcode',
+    bnum: 'nypl:Bnumber',
+    isbn: 'bf:Isbn',
+    issn: 'bf:Issn',
+    lccn: 'bf:Lccn',
+    oclc: 'nypl:Oclc'
+  }
+
+  // These are the three things we want to extract from identifiers in various
+  // forms:
+  let type = null
+  let value = null
+  let identifierStatus = null
+
+  // Is statement a blanknode?
+  if (statement._statements) {
+    type = statement.objectId('rdf:type')
+    value = statement.literal('rdf:value')
+    identifierStatus = statement.literal('bf:identifierStatus')
+
+  // Otherwise treat statement as a single statmeent (with type packed into
+  // value as a prefix or stored in object_type)
+  } else {
+    type = statement.object_type
+    if (!type && /^urn:\w+:/.test(statement.object_id)) {
+      type = urnPrefixMap[statement.object_id.split(':')[1]]
+    }
+    value = statement.object_id.replace(/^urn:\w+:/, '')
+  }
+
+  let urnStyle = statement.object_id
+  // Create urn style:
+  if (type && !/^urn:\w+:/.test(urnStyle)) {
+    // Derive prefix from object_type:
+    const prefix = Object.keys(urnPrefixMap)
+      .filter((prefix) => urnPrefixMap[prefix] === type)
+      .pop()
+    urnStyle = `urn:${prefix}:${value}`
+  }
+
+  const ret = {
+    urnStyle
+  }
+  if (type) {
+    ret.entityStyle = {
+      type,
+      value
+    }
+    if (identifierStatus) ret.entityStyle.identifierStatus = identifierStatus
+  }
+  return ret
+}
+
+ResourceItemSerializer.serialize = (item) => (new ResourceItemSerializer(item)).serialize()
+
+module.exports = ResourceItemSerializer

--- a/lib/serializers/resource-serializer.js
+++ b/lib/serializers/resource-serializer.js
@@ -1,48 +1,9 @@
 'use strict'
 
-const bibFieldMapper = require('./field-mapper')('bib')
-const itemFieldMapper = require('./field-mapper')('item')
-const log = require('loglevel')
-
-class EsSerializer {
-  constructor (object) {
-    this.object = object
-    this.statements = {}
-  }
-
-  addStatement (key, value, label, opts = {}) {
-    opts = Object.assign({
-      // By default, add a packed field if label is set
-      addPackedField: label
-    }, opts)
-
-    if (this.hasStatement(key, value)) return this
-
-    var _val = value
-    if (label) _val = { id: value, label: label }
-
-    if (!this.statements[key]) this.statements[key] = [_val]
-    else this.statements[key].push(_val)
-
-    if (opts.addPackedField) {
-      this.addPackedStatement(key, value, label)
-    }
-    return this
-  }
-
-  hasStatement (key, value) {
-    return this.statements[key] &&
-      (
-        ((typeof this.statements[key]) === 'object' && this.statements[key].indexOf(value) >= 0) ||
-        ((typeof this.statements[key]) !== 'object' && this.statements[key] === value)
-      )
-  }
-
-  addPackedStatement (key, value, label) {
-    var packedVal = [value, label].join('||')
-    return this.addStatement(`${key}_packed`, packedVal)
-  }
-}
+const bibFieldMapper = require('./../field-mapper')('bib')
+const EsSerializer = require('./es-serializer')
+const ResourceItemSerializer = require('./resource-item-serializer')
+const ResourceHoldingSerializer = require('./resource-holding-serializer')
 
 class ResourceSerializer extends EsSerializer {
   serialize () {
@@ -248,10 +209,10 @@ class ResourceSerializer extends EsSerializer {
     var promises = []
     promises.push(Promise.resolve())
 
-    if (this.object._items) {
-      // Ensure any non-electronic item that not have a shelfMark inherits one from bib
-      let defaultShelfMark = this.object.literals('nypl:shelfMark')
+    // Ensure any non-electronic item or holding that does not have a shelfMark inherits one from bib
+    let defaultShelfMark = this.object.literals('nypl:shelfMark')
 
+    if (this.object._items) {
       // Add `[bibid]-[itemid]` to bib-level `uris` property for each item to aid retrieval of unified bib-item object
       this.statements.uris = this.statements.uris.concat(this.object._items.map((i) => [this.statements.uri, i.id].join('-')))
 
@@ -287,6 +248,31 @@ class ResourceSerializer extends EsSerializer {
 
         var numAvailable = itemsSerialization.reduce((sum, item) => sum + (item.status && item.status.length > 0 && item.status[0].id === 'status:a' ? 1 : 0), 0)
         this.addStatement('numAvailable', numAvailable)
+      }))
+    }
+
+    if (this.object._holdings) {
+      this.statements.uris.push(...this.object._holdings.map((h) => `${this.statements.uri}-${h.id}`))
+
+      promises.push(Promise.all(this.object._holdings.map(ResourceHoldingSerializer.serialize)).then((holdingSerialization) => {
+        holdingSerialization = holdingSerialization.filter((h) => h)
+
+        this.statements['holdings'] = holdingSerialization
+          .map((holding) => {
+            if (!holding.shelfMark) holding.shelfMark = defaultShelfMark
+
+            // Add shelfMark to checkInBoxes
+            if (holding.checkInBoxes) {
+              holding.checkInBoxes.forEach((b) => {
+                b.shelfMark = holding.shelfMark
+              })
+
+              // Sort boxes by postion
+              holding.checkInBoxes.sort((b1, b2) => b1.position - b2.position)
+            }
+
+            return holding
+          })
       }))
     }
 
@@ -340,91 +326,6 @@ ResourceSerializer.sortableShelfMark = (shelfMark) => {
 ResourceSerializer.zeroPadString = (s, padLen = 6) => (new Array(Math.max(0, (padLen - s.length) + 1))).join('0') + s
 
 ResourceSerializer.serialize = (resource) => (new ResourceSerializer(resource)).serialize()
-
-class ResourceItemSerializer extends EsSerializer {
-  serialize () {
-    const fieldMapping = itemFieldMapper
-    // If Item is suppressed, fail serialization
-    var suppressed = this.object.literal(fieldMapping.predicateFor('Suppressed')) === 'true'
-    if (suppressed) {
-      log.info('Refusing to serialize suppressed ' + this.object.uri)
-      return null
-    }
-
-    this.statements['uri'] = this.object.uri
-
-    // Add entities:
-    ; [
-      'Availability',
-      'Content owner',
-      'Catalog item type',
-      'Holding location'
-    ].forEach((name) => {
-      itemFieldMapper.getMapping(name, (spec) => {
-        this.object.each(spec.pred, (triple) => {
-          this.addStatement(spec.jsonLdKey, triple.object_id, triple.object_label)
-        })
-      })
-    })
-
-    itemFieldMapper.getMapping('Call number', (spec) => {
-      this.object.each(spec.pred, (triple) => {
-        this.addStatement(spec.jsonLdKey, triple.object_literal)
-
-        this.addStatement('identifierV2', { value: triple.object_literal, type: 'bf:ShelfMark' })
-      })
-    })
-
-    // Add identifiers
-    const identifierPred = fieldMapping.predicateFor('Identifier')
-    const identifierValues = this.object.statements(identifierPred)
-      .map(parseIdentifierFromStatement)
-
-    // Index identifier entity to 'identifierV2':
-    identifierValues.forEach((identifier) => {
-      this.addStatement('identifier', identifier.urnStyle)
-
-      if (identifier.entityStyle) {
-        this.addStatement('identifierV2', identifier.entityStyle)
-
-        // Add special json-ld key based on type:
-        switch (identifier.entityStyle.type) {
-          case 'bf:Barcode':
-            this.addStatement('idBarcode', identifier.entityStyle.value)
-            break
-        }
-      }
-    })
-
-    // Note this comes from bib mapping because that's where it's extracted from:
-    bibFieldMapper.getMapping('Electronic location', (spec) => {
-      this.object.each(spec.pred, (triple) => {
-        this.addStatement(spec.jsonLdKey, { url: triple.object_literal, label: triple.object_label })
-      })
-      // TODO This is a temporary hack to fix fact most resources encoded using this incorrect pred:
-      // Remove this once statements remapped to 'bf:electronicLocator'
-      this.object.each('nypl:electronicLocator', (triple) => {
-        this.addStatement(spec.jsonLdKey, { url: triple.object_literal, label: triple.object_label })
-      })
-    })
-
-    var requestablePred = fieldMapping.predicateFor('Requestable')
-    if (this.object.has(requestablePred)) {
-      this.object.each(requestablePred, (triple) => {
-        this.addStatement('requestable', triple.object_literal === 'true')
-      })
-    }
-
-    var accessMessagePred = fieldMapping.predicateFor('Access message')
-    if (this.object.has(accessMessagePred)) {
-      this.object.each(accessMessagePred, (triple) => {
-        this.addStatement('accessMessage', triple.object_id, triple.object_label)
-      })
-    }
-
-    return this.statements
-  }
-}
 
 /**
  * Given a dcterms:identifier statement record, returns a plainobject
@@ -490,6 +391,4 @@ function parseIdentifierFromStatement (statement) {
   return ret
 }
 
-ResourceItemSerializer.serialize = (item) => (new ResourceItemSerializer(item)).serialize()
-
-module.exports = { ResourceSerializer }
+module.exports = ResourceSerializer

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "resolved": "https://registry.npmjs.org/@nypl/nypl-core-objects/-/nypl-core-objects-1.3.1.tgz",
       "integrity": "sha1-KKZn+nVXYdoEVnQkfWpsgqdUs34=",
       "requires": {
-        "jsonld": "0.4.12",
-        "just-flatten": "1.0.0",
-        "sync-request": "4.1.0"
+        "jsonld": "^0.4.5",
+        "just-flatten": "^1.0.0",
+        "sync-request": "^4.1.0"
       }
     },
     "@nypl/nypl-data-api-client": {
@@ -19,10 +19,10 @@
       "resolved": "https://registry.npmjs.org/@nypl/nypl-data-api-client/-/nypl-data-api-client-0.1.1.tgz",
       "integrity": "sha1-NhSuPBViuP/kaabj5p1Foy9Xrsw=",
       "requires": {
-        "loglevel": "1.6.1",
-        "node-cache": "4.2.0",
-        "oauth": "0.9.15",
-        "request": "2.86.0"
+        "loglevel": "^1.4.1",
+        "node-cache": "^4.1.1",
+        "oauth": "^0.9.15",
+        "request": "^2.81.0"
       }
     },
     "@nypl/nypl-streams-client": {
@@ -30,11 +30,11 @@
       "resolved": "https://registry.npmjs.org/@nypl/nypl-streams-client/-/nypl-streams-client-0.1.4.tgz",
       "integrity": "sha1-/vYIIhtkz4GR4nQ35rlbIeIxno8=",
       "requires": {
-        "@nypl/nypl-data-api-client": "0.1.1",
-        "avsc": "5.2.3",
-        "aws-sdk": "2.241.1",
-        "loglevel": "1.6.1",
-        "minimist": "1.2.0"
+        "@nypl/nypl-data-api-client": "^0.1.1",
+        "avsc": "^5.0.2",
+        "aws-sdk": "^2.50.0",
+        "loglevel": "^1.4.1",
+        "minimist": "^1.2.0"
       }
     },
     "@sinonjs/formatio": {
@@ -51,8 +51,8 @@
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
       "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
       "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
       }
     },
     "abbrev": {
@@ -72,7 +72,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -89,7 +89,7 @@
       "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
       "dev": true,
       "requires": {
-        "es6-promisify": "5.0.0"
+        "es6-promisify": "^5.0.0"
       }
     },
     "agentkeepalive": {
@@ -102,10 +102,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ajv-keywords": {
@@ -135,7 +135,7 @@
       "resolved": "https://registry.npmjs.org/ansi-term/-/ansi-term-0.0.2.tgz",
       "integrity": "sha1-/XU++kvq2g6smZgbxSo/b/AZ3rc=",
       "requires": {
-        "x256": "0.0.2"
+        "x256": ">=0.0.1"
       }
     },
     "ansicolors": {
@@ -149,14 +149,14 @@
       "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
       "dev": true,
       "requires": {
-        "archiver-utils": "1.3.0",
-        "async": "2.6.0",
-        "buffer-crc32": "0.2.13",
-        "glob": "7.1.1",
-        "lodash": "4.17.10",
-        "readable-stream": "2.3.6",
-        "tar-stream": "1.6.1",
-        "zip-stream": "1.2.0"
+        "archiver-utils": "^1.3.0",
+        "async": "^2.0.0",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.0.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0",
+        "tar-stream": "^1.5.0",
+        "zip-stream": "^1.2.0"
       },
       "dependencies": {
         "async": {
@@ -165,7 +165,7 @@
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.10"
+            "lodash": "^4.14.0"
           }
         }
       }
@@ -176,12 +176,12 @@
       "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
       "dev": true,
       "requires": {
-        "glob": "7.1.1",
-        "graceful-fs": "4.1.11",
-        "lazystream": "1.0.0",
-        "lodash": "4.17.10",
-        "normalize-path": "2.1.1",
-        "readable-stream": "2.3.6"
+        "glob": "^7.0.0",
+        "graceful-fs": "^4.1.0",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.8.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
       }
     },
     "argparse": {
@@ -190,7 +190,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arguments-extended": {
@@ -198,8 +198,8 @@
       "resolved": "https://registry.npmjs.org/arguments-extended/-/arguments-extended-0.0.3.tgz",
       "integrity": "sha1-YQfkkX0OtvCk3WYyD8Fa/HLvSUY=",
       "requires": {
-        "extended": "0.0.6",
-        "is-extended": "0.0.10"
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.8"
       }
     },
     "array-extended": {
@@ -207,9 +207,9 @@
       "resolved": "https://registry.npmjs.org/array-extended/-/array-extended-0.0.11.tgz",
       "integrity": "sha1-1xRK50jek8pybxIQCdv/FibRZL0=",
       "requires": {
-        "arguments-extended": "0.0.3",
-        "extended": "0.0.6",
-        "is-extended": "0.0.10"
+        "arguments-extended": "~0.0.3",
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.3"
       }
     },
     "array-union": {
@@ -218,7 +218,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -271,8 +271,8 @@
       "integrity": "sha512-E7Z2/QMs0EPt/o9wpYO/J3hmMCDdr1aVDS3ttlur5D5JlZtxhfuOwi4e7S8zbYIxA5qOOYdxfqGj97XAfdNvkQ==",
       "dev": true,
       "requires": {
-        "semver": "5.5.0",
-        "shimmer": "1.2.0"
+        "semver": "^5.3.0",
+        "shimmer": "^1.1.0"
       },
       "dependencies": {
         "semver": {
@@ -327,12 +327,12 @@
       "integrity": "sha512-HOSVn0O7ZXKTTgGErpG8GjFfSxhK5vfihqNAPoyi7GYMB16Y25BeWBkfpYVOEWWGYL/9bDcBcRAVc1NJwVJiHQ==",
       "dev": true,
       "requires": {
-        "continuation-local-storage": "3.2.1",
-        "moment": "2.22.1",
-        "pkginfo": "0.4.1",
-        "semver": "5.5.0",
-        "underscore": "1.9.0",
-        "winston": "2.4.2"
+        "continuation-local-storage": "^3.2.0",
+        "moment": "^2.15.2",
+        "pkginfo": "^0.4.0",
+        "semver": "^5.3.0",
+        "underscore": "^1.8.3",
+        "winston": "^2.2.0"
       },
       "dependencies": {
         "semver": {
@@ -365,7 +365,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bl": {
@@ -374,8 +374,8 @@
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.2"
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "blessed": {
@@ -388,21 +388,21 @@
       "resolved": "https://registry.npmjs.org/blessed-contrib/-/blessed-contrib-3.5.5.tgz",
       "integrity": "sha1-hbKV4wNjBUeX3NOnv0ek5bvf44w=",
       "requires": {
-        "ansi-term": "0.0.2",
-        "chalk": "1.1.3",
-        "drawille-canvas-blessed-contrib": "0.1.3",
-        "lodash": "4.17.10",
-        "map-canvas": "0.1.5",
-        "marked": "0.3.19",
-        "marked-terminal": "1.7.0",
-        "memory-streams": "0.1.3",
-        "memorystream": "0.3.1",
+        "ansi-term": ">=0.0.2",
+        "chalk": "^1.1.0",
+        "drawille-canvas-blessed-contrib": ">=0.1.3",
+        "lodash": ">=3.0.0",
+        "map-canvas": ">=0.1.5",
+        "marked": "^0.3.3",
+        "marked-terminal": "^1.5.0",
+        "memory-streams": "^0.1.0",
+        "memorystream": "^0.3.1",
         "picture-tube": "0.0.4",
-        "request": "2.86.0",
-        "sparkline": "0.1.2",
-        "strip-ansi": "3.0.1",
+        "request": "^2.53.0",
+        "sparkline": "^0.1.1",
+        "strip-ansi": "^3.0.0",
         "term-canvas": "0.0.5",
-        "x256": "0.0.2"
+        "x256": ">=0.0.1"
       }
     },
     "boom": {
@@ -410,7 +410,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "brace-expansion": {
@@ -419,7 +419,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -444,9 +444,9 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-alloc": {
@@ -455,8 +455,8 @@
       "integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
       "dev": true,
       "requires": {
-        "buffer-alloc-unsafe": "0.1.1",
-        "buffer-fill": "0.1.1"
+        "buffer-alloc-unsafe": "^0.1.0",
+        "buffer-fill": "^0.1.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -503,16 +503,16 @@
       "integrity": "sha1-cH/gJv/O3crL/c3zVur9pk8VEEY=",
       "dev": true,
       "requires": {
-        "cssmin": "0.3.2",
-        "jsmin": "1.0.1",
-        "jxLoader": "0.1.1",
-        "moo-server": "1.3.0",
-        "promised-io": "0.3.5",
-        "timespan": "2.3.0",
-        "uglify-js": "1.3.5",
-        "walker": "1.0.7",
-        "winston": "2.4.2",
-        "wrench": "1.3.9"
+        "cssmin": "0.3.x",
+        "jsmin": "1.x",
+        "jxLoader": "*",
+        "moo-server": "*",
+        "promised-io": "*",
+        "timespan": "2.x",
+        "uglify-js": "1.x",
+        "walker": "1.x",
+        "winston": "*",
+        "wrench": "1.3.x"
       }
     },
     "bytes": {
@@ -527,7 +527,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -541,8 +541,8 @@
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
       "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
       "requires": {
-        "ansicolors": "0.2.1",
-        "redeyed": "1.0.1"
+        "ansicolors": "~0.2.1",
+        "redeyed": "~1.0.0"
       }
     },
     "caseless": {
@@ -556,12 +556,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.8"
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       }
     },
     "chalk": {
@@ -569,11 +569,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "charm": {
@@ -599,7 +599,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^1.0.1"
       }
     },
     "cli-table": {
@@ -642,7 +642,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "command-exists": {
@@ -656,7 +656,7 @@
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
-        "graceful-readlink": "1.0.1"
+        "graceful-readlink": ">= 1.0.0"
       }
     },
     "compress-commons": {
@@ -665,10 +665,10 @@
       "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "0.2.13",
-        "crc32-stream": "2.0.0",
-        "normalize-path": "2.1.1",
-        "readable-stream": "2.3.6"
+        "buffer-crc32": "^0.2.1",
+        "crc32-stream": "^2.0.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
       }
     },
     "concat-map": {
@@ -682,10 +682,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "1.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "continuation-local-storage": {
@@ -694,8 +694,8 @@
       "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
       "dev": true,
       "requires": {
-        "async-listener": "0.6.9",
-        "emitter-listener": "1.1.1"
+        "async-listener": "^0.6.0",
+        "emitter-listener": "^1.1.1"
       }
     },
     "core-util-is": {
@@ -715,8 +715,8 @@
       "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
       "dev": true,
       "requires": {
-        "crc": "3.5.0",
-        "readable-stream": "2.3.6"
+        "crc": "^3.4.4",
+        "readable-stream": "^2.0.0"
       }
     },
     "cryptiles": {
@@ -724,7 +724,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -732,7 +732,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.2.1"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -754,7 +754,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.42"
+        "es5-ext": "^0.10.9"
       }
     },
     "dashdash": {
@@ -762,7 +762,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "data-uri-to-buffer": {
@@ -776,9 +776,9 @@
       "resolved": "https://registry.npmjs.org/date-extended/-/date-extended-0.0.6.tgz",
       "integrity": "sha1-I4AtV90b94GIE/4MMuhRqG2iZ8k=",
       "requires": {
-        "array-extended": "0.0.11",
-        "extended": "0.0.6",
-        "is-extended": "0.0.10"
+        "array-extended": "~0.0.3",
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.3"
       }
     },
     "debug": {
@@ -807,7 +807,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "deep-is": {
@@ -822,7 +822,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "1.0.4"
+        "clone": "^1.0.2"
       },
       "dependencies": {
         "clone": {
@@ -839,9 +839,9 @@
       "integrity": "sha1-/PSQo37OJmRk2cxDGrmMWBnO0JU=",
       "dev": true,
       "requires": {
-        "ast-types": "0.11.3",
-        "escodegen": "1.9.1",
-        "esprima": "3.0.0"
+        "ast-types": "0.x.x",
+        "escodegen": "1.x.x",
+        "esprima": "3.x.x"
       }
     },
     "deglob": {
@@ -850,13 +850,13 @@
       "integrity": "sha1-dtV3wl/j9zKUEqK1nq3qV6xQDj8=",
       "dev": true,
       "requires": {
-        "find-root": "1.1.0",
-        "glob": "7.1.1",
-        "ignore": "3.3.8",
-        "pkg-config": "1.1.1",
-        "run-parallel": "1.1.9",
-        "uniq": "1.0.1",
-        "xtend": "4.0.1"
+        "find-root": "^1.0.0",
+        "glob": "^7.0.5",
+        "ignore": "^3.0.9",
+        "pkg-config": "^1.1.0",
+        "run-parallel": "^1.1.2",
+        "uniq": "^1.0.1",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "ignore": {
@@ -873,13 +873,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "object-assign": "4.1.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "delayed-stream": {
@@ -900,11 +900,12 @@
       "dev": true
     },
     "discovery-store-models": {
-      "version": "git+https://github.com/NYPL-discovery/discovery-store-models.git#09653683bbfc9d0c316729b7d3dea328a13d0598",
+      "version": "git+https://github.com/NYPL-discovery/discovery-store-models.git#1c233353aaa0ffbd9e6027a45274420b18f5519c",
+      "from": "git+https://github.com/NYPL-discovery/discovery-store-models.git#v1.3.0",
       "requires": {
-        "@nypl/nypl-core-objects": "1.3.1",
-        "pg-promise": "7.5.4",
-        "winston": "2.4.2"
+        "@nypl/nypl-core-objects": "^1.3.1",
+        "pg-promise": "^7.4.0",
+        "winston": "^2.4.0"
       },
       "dependencies": {
         "pg-promise": {
@@ -912,10 +913,10 @@
           "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-7.5.4.tgz",
           "integrity": "sha512-wuL+13P+Ris8MEUpdatv7OH5eHEahWBNmgGHEwLd88fym/eMAjxrFV+3jRKO7bFAyDTvo3wNcmuntYwR9eJnvg==",
           "requires": {
-            "manakin": "0.5.1",
-            "pg": "7.4.3",
-            "pg-minify": "0.5.4",
-            "spex": "2.0.2"
+            "manakin": "~0.5.1",
+            "pg": "~7.4.1",
+            "pg-minify": "~0.5.4",
+            "spex": "~2.0.2"
           }
         }
       }
@@ -926,8 +927,8 @@
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
       }
     },
     "dotenv": {
@@ -945,11 +946,11 @@
       "resolved": "https://registry.npmjs.org/drawille-canvas-blessed-contrib/-/drawille-canvas-blessed-contrib-0.1.3.tgz",
       "integrity": "sha1-IS8HinIr/S7MJn6oarbd3BCB/Ug=",
       "requires": {
-        "ansi-term": "0.0.2",
+        "ansi-term": ">=0.0.2",
         "bresenham": "0.0.3",
-        "drawille-blessed-contrib": "1.0.0",
-        "gl-matrix": "2.5.1",
-        "x256": "0.0.2"
+        "drawille-blessed-contrib": ">=0.0.1",
+        "gl-matrix": "^2.1.0",
+        "x256": ">=0.0.1"
       }
     },
     "ecc-jsbn": {
@@ -958,7 +959,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "elasticsearch": {
@@ -966,12 +967,12 @@
       "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-13.3.1.tgz",
       "integrity": "sha1-xTCuqa+xfqkcPQpW8fERukm8kjk=",
       "requires": {
-        "agentkeepalive": "2.2.0",
-        "chalk": "1.1.3",
+        "agentkeepalive": "^2.2.0",
+        "chalk": "^1.0.0",
         "lodash": "2.4.2",
-        "lodash.get": "4.4.2",
-        "lodash.isempty": "4.4.0",
-        "lodash.trimend": "4.5.1"
+        "lodash.get": "^4.4.2",
+        "lodash.isempty": "^4.4.0",
+        "lodash.trimend": "^4.5.1"
       },
       "dependencies": {
         "lodash": {
@@ -987,7 +988,7 @@
       "integrity": "sha1-6Lu+gkS8jg0LTvcc0UKUx/JBx+w=",
       "dev": true,
       "requires": {
-        "shimmer": "1.2.0"
+        "shimmer": "^1.2.0"
       }
     },
     "end-of-stream": {
@@ -996,7 +997,7 @@
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "es5-ext": {
@@ -1005,9 +1006,9 @@
       "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1",
-        "next-tick": "1.0.0"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "1"
       }
     },
     "es6-iterator": {
@@ -1016,9 +1017,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-map": {
@@ -1027,12 +1028,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-promise": {
@@ -1046,7 +1047,7 @@
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
-        "es6-promise": "4.2.4"
+        "es6-promise": "^4.0.3"
       },
       "dependencies": {
         "es6-promise": {
@@ -1063,11 +1064,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-iterator": "2.0.3",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-symbol": {
@@ -1076,8 +1077,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "es6-weak-map": {
@@ -1086,10 +1087,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -1103,11 +1104,11 @@
       "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "dev": true,
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.6.1"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -1124,10 +1125,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint": {
@@ -1136,39 +1137,39 @@
       "integrity": "sha1-bI10OpFUZZW6GG7e0JZoL0dZjeg=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "concat-stream": "1.6.2",
-        "debug": "2.6.8",
-        "doctrine": "1.5.0",
-        "es6-map": "0.1.5",
-        "escope": "3.6.0",
-        "espree": "3.5.4",
-        "estraverse": "4.2.0",
-        "estraverse-fb": "1.3.2",
-        "esutils": "2.0.2",
-        "file-entry-cache": "1.3.1",
-        "glob": "6.0.4",
-        "globals": "8.18.0",
-        "ignore": "2.2.19",
-        "inquirer": "0.12.0",
-        "is-my-json-valid": "2.17.2",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.11.0",
-        "json-stable-stringify": "1.0.1",
-        "lodash": "4.17.10",
-        "mkdirp": "0.5.1",
-        "optionator": "0.8.2",
-        "path-is-absolute": "1.0.1",
-        "path-is-inside": "1.0.2",
-        "pluralize": "1.2.1",
-        "progress": "1.1.8",
-        "require-uncached": "1.0.3",
-        "resolve": "1.7.1",
-        "shelljs": "0.5.3",
-        "strip-json-comments": "1.0.4",
-        "table": "3.8.3",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0"
+        "chalk": "^1.0.0",
+        "concat-stream": "^1.4.6",
+        "debug": "^2.1.1",
+        "doctrine": "^1.1.0",
+        "es6-map": "^0.1.3",
+        "escope": "^3.4.0",
+        "espree": "^3.0.0",
+        "estraverse": "^4.1.1",
+        "estraverse-fb": "^1.3.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^1.1.1",
+        "glob": "^6.0.4",
+        "globals": "^8.18.0",
+        "ignore": "^2.2.19",
+        "inquirer": "^0.12.0",
+        "is-my-json-valid": "^2.10.0",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.5.1",
+        "json-stable-stringify": "^1.0.0",
+        "lodash": "^4.0.0",
+        "mkdirp": "^0.5.0",
+        "optionator": "^0.8.1",
+        "path-is-absolute": "^1.0.0",
+        "path-is-inside": "^1.0.1",
+        "pluralize": "^1.2.1",
+        "progress": "^1.1.8",
+        "require-uncached": "^1.0.2",
+        "resolve": "^1.1.6",
+        "shelljs": "^0.5.3",
+        "strip-json-comments": "~1.0.1",
+        "table": "^3.7.8",
+        "text-table": "~0.2.0",
+        "user-home": "^2.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -1183,11 +1184,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "js-yaml": {
@@ -1196,8 +1197,8 @@
           "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
           "dev": true,
           "requires": {
-            "argparse": "1.0.10",
-            "esprima": "4.0.0"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         }
       }
@@ -1238,8 +1239,8 @@
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -1253,7 +1254,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -1280,8 +1281,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "event-stream": {
@@ -1289,7 +1290,7 @@
       "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-0.9.8.tgz",
       "integrity": "sha1-XanPPHkAl1mJ21powo5bPJjr4Do=",
       "requires": {
-        "optimist": "0.2.8"
+        "optimist": "0.2"
       },
       "dependencies": {
         "optimist": {
@@ -1297,7 +1298,7 @@
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
           "integrity": "sha1-6YGrfiaLRXlIWTtVZ0wJmoFcrDE=",
           "requires": {
-            "wordwrap": "0.0.3"
+            "wordwrap": ">=0.0.1 <0.1.0"
           }
         }
       }
@@ -1323,7 +1324,7 @@
       "resolved": "https://registry.npmjs.org/extended/-/extended-0.0.6.tgz",
       "integrity": "sha1-f7i/e52uOXWG5IVwrP1kLHjlBmk=",
       "requires": {
-        "extender": "0.0.10"
+        "extender": "~0.0.5"
       }
     },
     "extender": {
@@ -1331,7 +1332,7 @@
       "resolved": "https://registry.npmjs.org/extender/-/extender-0.0.10.tgz",
       "integrity": "sha1-WJwHSCvmGhRgttgfnCSqZ+jzJM0=",
       "requires": {
-        "declare.js": "0.0.8"
+        "declare.js": "~0.0.4"
       }
     },
     "extsprintf": {
@@ -1377,8 +1378,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.0"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "file-entry-cache": {
@@ -1387,8 +1388,8 @@
       "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.0"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "file-uri-to-path": {
@@ -1409,10 +1410,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "forever-agent": {
@@ -1425,9 +1426,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
     },
     "formatio": {
@@ -1436,7 +1437,7 @@
       "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "samsam": "1.x"
       }
     },
     "fs-constants": {
@@ -1451,11 +1452,11 @@
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "fs.realpath": {
@@ -1470,7 +1471,7 @@
       "integrity": "sha1-kZfYYa2BQvPmPVqDv+TFn3MwiF0=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14",
+        "readable-stream": "1.1.x",
         "xregexp": "2.0.0"
       },
       "dependencies": {
@@ -1486,10 +1487,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -1512,7 +1513,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "generic-pool": {
@@ -1543,12 +1544,12 @@
       "integrity": "sha512-ZD325dMZOgerGqF/rF6vZXyFGTAay62svjQIT+X/oU2PtxYpFxvSkbsdi+oxIrsNxlZVd4y8wUDqkaExWTI/Cw==",
       "dev": true,
       "requires": {
-        "data-uri-to-buffer": "1.2.0",
-        "debug": "2.6.8",
-        "extend": "3.0.1",
-        "file-uri-to-path": "1.0.0",
-        "ftp": "0.3.10",
-        "readable-stream": "2.3.6"
+        "data-uri-to-buffer": "1",
+        "debug": "2",
+        "extend": "3",
+        "file-uri-to-path": "1",
+        "ftp": "~0.3.10",
+        "readable-stream": "2"
       }
     },
     "getpass": {
@@ -1556,7 +1557,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "gl-matrix": {
@@ -1564,7 +1565,7 @@
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-2.5.1.tgz",
       "integrity": "sha512-GCv0L5v+2Hdh+al6Ny7MO4B+BfXd6qfUom6CE5O/nqkBvaIY7+dVZhuKad+EkUK0uyot8V6TkgsMQrQzlmZl2A==",
       "requires": {
-        "npm": "5.10.0"
+        "npm": "^5.8.0"
       }
     },
     "glob": {
@@ -1573,12 +1574,12 @@
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globals": {
@@ -1593,12 +1594,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.1",
-        "object-assign": "4.1.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "graceful-fs": {
@@ -1629,8 +1630,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has-ansi": {
@@ -1638,7 +1639,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -1652,10 +1653,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "he": {
@@ -1674,7 +1675,7 @@
       "resolved": "https://registry.npmjs.org/highland/-/highland-2.13.0.tgz",
       "integrity": "sha512-zGZBcgAHPY2Zf9VG9S5IrlcC7CH9ELioXVtp9T5bU2a4fP2zIsA+Y8pV/n/h2lMwbWMHTX0I0xN0ODJ3Pd3aBQ==",
       "requires": {
-        "util-deprecate": "1.0.2"
+        "util-deprecate": "^1.0.2"
       }
     },
     "hoek": {
@@ -1687,9 +1688,9 @@
       "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-2.5.1.tgz",
       "integrity": "sha1-jORHvbW2xXf4pj4/p4BW7Eu02/s=",
       "requires": {
-        "caseless": "0.11.0",
-        "concat-stream": "1.6.2",
-        "http-response-object": "1.1.0"
+        "caseless": "~0.11.0",
+        "concat-stream": "^1.4.6",
+        "http-response-object": "^1.0.0"
       },
       "dependencies": {
         "caseless": {
@@ -1705,10 +1706,10 @@
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.5.0"
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "http-proxy-agent": {
@@ -1717,7 +1718,7 @@
       "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
       "dev": true,
       "requires": {
-        "agent-base": "4.2.0",
+        "agent-base": "4",
         "debug": "3.1.0"
       },
       "dependencies": {
@@ -1742,9 +1743,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -1753,8 +1754,8 @@
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
       "requires": {
-        "agent-base": "4.2.0",
-        "debug": "3.1.0"
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
       },
       "dependencies": {
         "debug": {
@@ -1774,7 +1775,7 @@
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ieee754": {
@@ -1794,8 +1795,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1809,19 +1810,19 @@
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.2.0",
-        "figures": "1.7.0",
-        "lodash": "4.17.10",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
       }
     },
     "ip": {
@@ -1835,7 +1836,7 @@
       "resolved": "https://registry.npmjs.org/is-extended/-/is-extended-0.0.10.tgz",
       "integrity": "sha1-JE4UDfdbscmjEG9BL/GC+1NKbWI=",
       "requires": {
-        "extended": "0.0.6"
+        "extended": "~0.0.3"
       }
     },
     "is-fullwidth-code-point": {
@@ -1844,7 +1845,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-my-ip-valid": {
@@ -1859,11 +1860,11 @@
       "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
       "dev": true,
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "is-my-ip-valid": "1.0.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-path-cwd": {
@@ -1878,7 +1879,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -1887,7 +1888,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-property": {
@@ -1961,7 +1962,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -1981,7 +1982,7 @@
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -1995,9 +1996,9 @@
       "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-0.4.12.tgz",
       "integrity": "sha1-oC8gXVNBQU3xtthBTxuWenEgc+g=",
       "requires": {
-        "es6-promise": "2.3.0",
-        "pkginfo": "0.4.1",
-        "request": "2.86.0",
+        "es6-promise": "^2.0.0",
+        "pkginfo": "~0.4.0",
+        "request": "^2.61.0",
         "xmldom": "0.1.19"
       }
     },
@@ -2040,10 +2041,10 @@
       "integrity": "sha1-ATTqUUTlM7WU/B/yX/GU4jXFPs0=",
       "dev": true,
       "requires": {
-        "js-yaml": "0.3.7",
-        "moo-server": "1.3.0",
-        "promised-io": "0.3.5",
-        "walker": "1.0.7"
+        "js-yaml": "0.3.x",
+        "moo-server": "1.3.x",
+        "promised-io": "*",
+        "walker": "1.x"
       }
     },
     "klaw": {
@@ -2052,7 +2053,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "lazystream": {
@@ -2061,7 +2062,7 @@
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.5"
       }
     },
     "levn": {
@@ -2070,8 +2071,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lodash": {
@@ -2085,8 +2086,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -2124,9 +2125,9 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.get": {
@@ -2157,9 +2158,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lodash.toarray": {
@@ -2189,8 +2190,8 @@
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "makeerror": {
@@ -2199,21 +2200,21 @@
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
-        "tmpl": "1.0.4"
+        "tmpl": "1.0.x"
       }
     },
     "manakin": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/manakin/-/manakin-0.5.1.tgz",
-      "integrity": "sha1-xKcRb2sA3z1fGjetPKUV0iBlplg="
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/manakin/-/manakin-0.5.2.tgz",
+      "integrity": "sha512-pfDSB7QYoVg0Io4KMV9hhPoXpj6p0uBscgtyUSKCOFZe8bqgbpStfgnKIbF/ulnr6U3ICu4OqdyxAqBgOhZwBQ=="
     },
     "map-canvas": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/map-canvas/-/map-canvas-0.1.5.tgz",
       "integrity": "sha1-i+a63gvz6fmotW6INqHR0TPKsYY=",
       "requires": {
-        "drawille-canvas-blessed-contrib": "0.1.3",
-        "xml2js": "0.4.17"
+        "drawille-canvas-blessed-contrib": ">=0.0.1",
+        "xml2js": "^0.4.5"
       }
     },
     "marked": {
@@ -2226,11 +2227,11 @@
       "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.7.0.tgz",
       "integrity": "sha1-yMRgiBx3LHYEtkNnAH7l938SWQQ=",
       "requires": {
-        "cardinal": "1.0.0",
-        "chalk": "1.1.3",
-        "cli-table": "0.3.1",
-        "lodash.assign": "4.2.0",
-        "node-emoji": "1.8.1"
+        "cardinal": "^1.0.0",
+        "chalk": "^1.1.3",
+        "cli-table": "^0.3.1",
+        "lodash.assign": "^4.2.0",
+        "node-emoji": "^1.4.1"
       }
     },
     "memory-streams": {
@@ -2238,7 +2239,7 @@
       "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.3.tgz",
       "integrity": "sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==",
       "requires": {
-        "readable-stream": "1.0.34"
+        "readable-stream": "~1.0.2"
       },
       "dependencies": {
         "isarray": {
@@ -2251,10 +2252,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -2279,7 +2280,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "minimatch": {
@@ -2288,7 +2289,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -2339,7 +2340,7 @@
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -2375,13 +2376,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
           "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
           "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -2389,7 +2390,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -2399,8 +2400,8 @@
       "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.19.tgz",
       "integrity": "sha512-Jt4AtWUkpuW03kRdYGxga4O65O1UHlFfvvInslEfLlGi+zDMxbBe3J2NVmN9qPJ957Mn6Iz0UpMtV80cmxCVxw==",
       "requires": {
-        "bson": "1.0.6",
-        "require_optional": "1.0.1"
+        "bson": "~1.0.4",
+        "require_optional": "~1.0.0"
       }
     },
     "moo-server": {
@@ -2421,7 +2422,7 @@
       "integrity": "sha1-abHyX/B00oKJBPJE3dBrfZbvbJM=",
       "dev": true,
       "requires": {
-        "strip-indent": "1.0.1"
+        "strip-indent": "^1.0.0"
       }
     },
     "mute-stream": {
@@ -2454,11 +2455,11 @@
       "integrity": "sha512-v1J/FLUB9PfGqZLGDBhQqODkbLotP0WtLo9R4EJY2PPu5f5Xg4o0rA8FDlmrjFSv9vBBKcfnOSpfYYuu5RTHqg==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "2.0.0",
-        "just-extend": "1.1.27",
-        "lolex": "2.6.0",
-        "path-to-regexp": "1.7.0",
-        "text-encoding": "0.6.4"
+        "@sinonjs/formatio": "^2.0.0",
+        "just-extend": "^1.1.27",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
       }
     },
     "node-cache": {
@@ -2466,8 +2467,8 @@
       "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.0.tgz",
       "integrity": "sha512-obRu6/f7S024ysheAjoYFEEBqqDWv4LOMNJEuO8vMeEw2AT4z+NCzO4hlc2lhI4vATzbCQv6kke9FVdx0RbCOw==",
       "requires": {
-        "clone": "2.1.1",
-        "lodash": "4.17.10"
+        "clone": "2.x",
+        "lodash": "4.x"
       }
     },
     "node-emoji": {
@@ -2475,7 +2476,7 @@
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
       "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
       "requires": {
-        "lodash.toarray": "4.4.0"
+        "lodash.toarray": "^4.4.0"
       }
     },
     "node-lambda": {
@@ -2484,15 +2485,15 @@
       "integrity": "sha512-1qvfYWJyLLVB3PxDSlEHVoTT4JsBdSkrFmCdpvbH0ghxd+EwssPkxATIO2hVvhAzDCSnaCxg0lSxZd8oG6xSVw==",
       "dev": true,
       "requires": {
-        "archiver": "2.1.1",
-        "aws-sdk": "2.241.1",
-        "aws-xray-sdk-core": "1.2.0",
-        "commander": "2.15.1",
-        "continuation-local-storage": "3.2.1",
-        "dotenv": "0.4.0",
-        "fs-extra": "0.30.0",
-        "minimatch": "3.0.4",
-        "proxy-agent": "2.3.1"
+        "archiver": "^2.1.1",
+        "aws-sdk": "^2.203.0",
+        "aws-xray-sdk-core": "^1.2.0",
+        "commander": "^2.14.1",
+        "continuation-local-storage": "^3.2.1",
+        "dotenv": "^0.4.0",
+        "fs-extra": "^0.30.0",
+        "minimatch": "^3.0.3",
+        "proxy-agent": "^2.2.0"
       },
       "dependencies": {
         "commander": {
@@ -2514,7 +2515,7 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
       "integrity": "sha1-bMzZd7gBMqB3MdbozljCyDA8+a8=",
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1"
       }
     },
     "normalize-path": {
@@ -2523,7 +2524,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "npm": {
@@ -2531,130 +2532,130 @@
       "resolved": "https://registry.npmjs.org/npm/-/npm-5.10.0.tgz",
       "integrity": "sha512-lvjvjgR5wG2RJ2uqak1xtZcVAWMwVOzN5HkUlUj/n8rU1f3A0fNn+7HwOzH9Lyf0Ppyu9ApgsEpHczOSnx1cwA==",
       "requires": {
-        "JSONStream": "1.3.2",
-        "abbrev": "1.1.1",
-        "ansi-regex": "3.0.0",
-        "ansicolors": "0.3.2",
-        "ansistyles": "0.1.3",
-        "aproba": "1.2.0",
-        "archy": "1.0.0",
-        "bin-links": "1.1.0",
-        "bluebird": "3.5.1",
-        "byte-size": "4.0.2",
-        "cacache": "10.0.4",
-        "call-limit": "1.1.0",
-        "chownr": "1.0.1",
-        "cli-columns": "3.1.2",
-        "cli-table2": "0.2.0",
-        "cmd-shim": "2.0.2",
-        "columnify": "1.5.4",
-        "config-chain": "1.1.11",
-        "debuglog": "1.0.1",
-        "detect-indent": "5.0.0",
-        "detect-newline": "2.1.0",
-        "dezalgo": "1.0.3",
-        "editor": "1.0.0",
-        "find-npm-prefix": "1.0.2",
-        "fs-vacuum": "1.2.10",
-        "fs-write-stream-atomic": "1.0.10",
-        "gentle-fs": "2.0.1",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "has-unicode": "2.0.1",
-        "hosted-git-info": "2.6.0",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "ini": "1.3.5",
-        "init-package-json": "1.10.3",
-        "is-cidr": "1.0.0",
-        "json-parse-better-errors": "1.0.2",
-        "lazy-property": "1.0.0",
-        "libcipm": "1.6.2",
-        "libnpx": "10.2.0",
-        "lock-verify": "2.0.2",
-        "lockfile": "1.0.4",
-        "lodash._baseindexof": "3.1.0",
-        "lodash._baseuniq": "4.6.0",
-        "lodash._bindcallback": "3.0.1",
-        "lodash._cacheindexof": "3.0.2",
-        "lodash._createcache": "3.1.2",
-        "lodash._getnative": "3.9.1",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.restparam": "3.6.1",
-        "lodash.union": "4.6.0",
-        "lodash.uniq": "4.5.0",
-        "lodash.without": "4.4.0",
-        "lru-cache": "4.1.2",
-        "meant": "1.0.1",
-        "mississippi": "3.0.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "node-gyp": "3.6.2",
-        "nopt": "4.0.1",
-        "normalize-package-data": "2.4.0",
-        "npm-audit-report": "1.0.9",
-        "npm-cache-filename": "1.0.2",
-        "npm-install-checks": "3.0.0",
-        "npm-lifecycle": "2.0.1",
-        "npm-package-arg": "6.1.0",
-        "npm-packlist": "1.1.10",
-        "npm-profile": "3.0.1",
-        "npm-registry-client": "8.5.1",
-        "npm-registry-fetch": "1.1.0",
-        "npm-user-validate": "1.0.0",
-        "npmlog": "4.1.2",
-        "once": "1.4.0",
-        "opener": "1.4.3",
-        "osenv": "0.1.5",
-        "pacote": "7.6.1",
-        "path-is-inside": "1.0.2",
-        "promise-inflight": "1.0.1",
-        "qrcode-terminal": "0.12.0",
-        "query-string": "6.1.0",
-        "qw": "1.0.1",
-        "read": "1.0.7",
-        "read-cmd-shim": "1.0.1",
-        "read-installed": "4.0.3",
-        "read-package-json": "2.0.13",
-        "read-package-tree": "5.2.1",
-        "readable-stream": "2.3.6",
-        "readdir-scoped-modules": "1.0.2",
-        "request": "2.85.0",
-        "retry": "0.12.0",
-        "rimraf": "2.6.2",
-        "safe-buffer": "5.1.2",
-        "semver": "5.5.0",
-        "sha": "2.0.1",
-        "slide": "1.1.6",
-        "sorted-object": "2.0.1",
-        "sorted-union-stream": "2.1.3",
-        "ssri": "5.3.0",
-        "strip-ansi": "4.0.0",
-        "tar": "4.4.2",
-        "text-table": "0.2.0",
-        "tiny-relative-date": "1.3.0",
+        "JSONStream": "^1.3.2",
+        "abbrev": "~1.1.1",
+        "ansi-regex": "~3.0.0",
+        "ansicolors": "~0.3.2",
+        "ansistyles": "~0.1.3",
+        "aproba": "~1.2.0",
+        "archy": "~1.0.0",
+        "bin-links": "^1.1.0",
+        "bluebird": "~3.5.1",
+        "byte-size": "^4.0.2",
+        "cacache": "^10.0.4",
+        "call-limit": "~1.1.0",
+        "chownr": "~1.0.1",
+        "cli-columns": "^3.1.2",
+        "cli-table2": "~0.2.0",
+        "cmd-shim": "~2.0.2",
+        "columnify": "~1.5.4",
+        "config-chain": "~1.1.11",
+        "debuglog": "*",
+        "detect-indent": "~5.0.0",
+        "detect-newline": "^2.1.0",
+        "dezalgo": "~1.0.3",
+        "editor": "~1.0.0",
+        "find-npm-prefix": "^1.0.2",
+        "fs-vacuum": "~1.2.10",
+        "fs-write-stream-atomic": "~1.0.10",
+        "gentle-fs": "^2.0.1",
+        "glob": "~7.1.2",
+        "graceful-fs": "~4.1.11",
+        "has-unicode": "~2.0.1",
+        "hosted-git-info": "^2.6.0",
+        "iferr": "~0.1.5",
+        "imurmurhash": "*",
+        "inflight": "~1.0.6",
+        "inherits": "~2.0.3",
+        "ini": "^1.3.5",
+        "init-package-json": "^1.10.3",
+        "is-cidr": "~1.0.0",
+        "json-parse-better-errors": "^1.0.2",
+        "lazy-property": "~1.0.0",
+        "libcipm": "^1.6.2",
+        "libnpx": "^10.2.0",
+        "lock-verify": "^2.0.2",
+        "lockfile": "^1.0.4",
+        "lodash._baseindexof": "*",
+        "lodash._baseuniq": "~4.6.0",
+        "lodash._bindcallback": "*",
+        "lodash._cacheindexof": "*",
+        "lodash._createcache": "*",
+        "lodash._getnative": "*",
+        "lodash.clonedeep": "~4.5.0",
+        "lodash.restparam": "*",
+        "lodash.union": "~4.6.0",
+        "lodash.uniq": "~4.5.0",
+        "lodash.without": "~4.4.0",
+        "lru-cache": "^4.1.2",
+        "meant": "~1.0.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "~0.5.1",
+        "move-concurrently": "^1.0.1",
+        "node-gyp": "^3.6.2",
+        "nopt": "~4.0.1",
+        "normalize-package-data": "~2.4.0",
+        "npm-audit-report": "^1.0.9",
+        "npm-cache-filename": "~1.0.2",
+        "npm-install-checks": "~3.0.0",
+        "npm-lifecycle": "^2.0.1",
+        "npm-package-arg": "^6.1.0",
+        "npm-packlist": "~1.1.10",
+        "npm-profile": "^3.0.1",
+        "npm-registry-client": "^8.5.1",
+        "npm-registry-fetch": "^1.1.0",
+        "npm-user-validate": "~1.0.0",
+        "npmlog": "~4.1.2",
+        "once": "~1.4.0",
+        "opener": "~1.4.3",
+        "osenv": "^0.1.5",
+        "pacote": "^7.6.1",
+        "path-is-inside": "~1.0.2",
+        "promise-inflight": "~1.0.1",
+        "qrcode-terminal": "^0.12.0",
+        "query-string": "^6.1.0",
+        "qw": "~1.0.1",
+        "read": "~1.0.7",
+        "read-cmd-shim": "~1.0.1",
+        "read-installed": "~4.0.3",
+        "read-package-json": "^2.0.13",
+        "read-package-tree": "^5.2.1",
+        "readable-stream": "^2.3.6",
+        "readdir-scoped-modules": "*",
+        "request": "^2.85.0",
+        "retry": "^0.12.0",
+        "rimraf": "~2.6.2",
+        "safe-buffer": "^5.1.2",
+        "semver": "^5.5.0",
+        "sha": "~2.0.1",
+        "slide": "~1.1.6",
+        "sorted-object": "~2.0.1",
+        "sorted-union-stream": "~2.1.3",
+        "ssri": "^5.3.0",
+        "strip-ansi": "~4.0.0",
+        "tar": "^4.4.2",
+        "text-table": "~0.2.0",
+        "tiny-relative-date": "^1.3.0",
         "uid-number": "0.0.6",
-        "umask": "1.1.0",
-        "unique-filename": "1.1.0",
-        "unpipe": "1.0.0",
-        "update-notifier": "2.5.0",
-        "uuid": "3.2.1",
-        "validate-npm-package-license": "3.0.3",
-        "validate-npm-package-name": "3.0.0",
-        "which": "1.3.0",
-        "worker-farm": "1.6.0",
-        "wrappy": "1.0.2",
-        "write-file-atomic": "2.3.0"
+        "umask": "~1.1.0",
+        "unique-filename": "~1.1.0",
+        "unpipe": "~1.0.0",
+        "update-notifier": "^2.5.0",
+        "uuid": "^3.2.1",
+        "validate-npm-package-license": "^3.0.3",
+        "validate-npm-package-name": "~3.0.0",
+        "which": "~1.3.0",
+        "worker-farm": "^1.6.0",
+        "wrappy": "~1.0.2",
+        "write-file-atomic": "^2.3.0"
       },
       "dependencies": {
         "JSONStream": {
           "version": "1.3.2",
           "bundled": true,
           "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
           },
           "dependencies": {
             "jsonparse": {
@@ -2695,12 +2696,12 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "cmd-shim": "2.0.2",
-            "fs-write-stream-atomic": "1.0.10",
-            "gentle-fs": "2.0.1",
-            "graceful-fs": "4.1.11",
-            "slide": "1.1.6"
+            "bluebird": "^3.5.0",
+            "cmd-shim": "^2.0.2",
+            "fs-write-stream-atomic": "^1.0.10",
+            "gentle-fs": "^2.0.0",
+            "graceful-fs": "^4.1.11",
+            "slide": "^1.1.6"
           }
         },
         "bluebird": {
@@ -2715,44 +2716,44 @@
           "version": "10.0.4",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "chownr": "1.0.1",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "lru-cache": "4.1.2",
-            "mississippi": "2.0.0",
-            "mkdirp": "0.5.1",
-            "move-concurrently": "1.0.1",
-            "promise-inflight": "1.0.1",
-            "rimraf": "2.6.2",
-            "ssri": "5.3.0",
-            "unique-filename": "1.1.0",
-            "y18n": "4.0.0"
+            "bluebird": "^3.5.1",
+            "chownr": "^1.0.1",
+            "glob": "^7.1.2",
+            "graceful-fs": "^4.1.11",
+            "lru-cache": "^4.1.1",
+            "mississippi": "^2.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "ssri": "^5.2.4",
+            "unique-filename": "^1.1.0",
+            "y18n": "^4.0.0"
           },
           "dependencies": {
             "mississippi": {
               "version": "2.0.0",
               "bundled": true,
               "requires": {
-                "concat-stream": "1.6.1",
-                "duplexify": "3.5.4",
-                "end-of-stream": "1.4.1",
-                "flush-write-stream": "1.0.2",
-                "from2": "2.3.0",
-                "parallel-transform": "1.1.0",
-                "pump": "2.0.1",
-                "pumpify": "1.4.0",
-                "stream-each": "1.2.2",
-                "through2": "2.0.3"
+                "concat-stream": "^1.5.0",
+                "duplexify": "^3.4.2",
+                "end-of-stream": "^1.1.0",
+                "flush-write-stream": "^1.0.0",
+                "from2": "^2.1.0",
+                "parallel-transform": "^1.1.0",
+                "pump": "^2.0.1",
+                "pumpify": "^1.3.3",
+                "stream-each": "^1.1.0",
+                "through2": "^2.0.0"
               },
               "dependencies": {
                 "concat-stream": {
                   "version": "1.6.1",
                   "bundled": true,
                   "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.6",
-                    "typedarray": "0.0.6"
+                    "inherits": "^2.0.3",
+                    "readable-stream": "^2.2.2",
+                    "typedarray": "^0.0.6"
                   },
                   "dependencies": {
                     "typedarray": {
@@ -2765,10 +2766,10 @@
                   "version": "3.5.4",
                   "bundled": true,
                   "requires": {
-                    "end-of-stream": "1.4.1",
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.6",
-                    "stream-shift": "1.0.0"
+                    "end-of-stream": "^1.0.0",
+                    "inherits": "^2.0.1",
+                    "readable-stream": "^2.0.0",
+                    "stream-shift": "^1.0.0"
                   },
                   "dependencies": {
                     "stream-shift": {
@@ -2781,32 +2782,32 @@
                   "version": "1.4.1",
                   "bundled": true,
                   "requires": {
-                    "once": "1.4.0"
+                    "once": "^1.4.0"
                   }
                 },
                 "flush-write-stream": {
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.6"
+                    "inherits": "^2.0.1",
+                    "readable-stream": "^2.0.4"
                   }
                 },
                 "from2": {
                   "version": "2.3.0",
                   "bundled": true,
                   "requires": {
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.6"
+                    "inherits": "^2.0.1",
+                    "readable-stream": "^2.0.0"
                   }
                 },
                 "parallel-transform": {
                   "version": "1.1.0",
                   "bundled": true,
                   "requires": {
-                    "cyclist": "0.2.2",
-                    "inherits": "2.0.3",
-                    "readable-stream": "2.3.6"
+                    "cyclist": "~0.2.2",
+                    "inherits": "^2.0.3",
+                    "readable-stream": "^2.1.5"
                   },
                   "dependencies": {
                     "cyclist": {
@@ -2819,25 +2820,25 @@
                   "version": "2.0.1",
                   "bundled": true,
                   "requires": {
-                    "end-of-stream": "1.4.1",
-                    "once": "1.4.0"
+                    "end-of-stream": "^1.1.0",
+                    "once": "^1.3.1"
                   }
                 },
                 "pumpify": {
                   "version": "1.4.0",
                   "bundled": true,
                   "requires": {
-                    "duplexify": "3.5.4",
-                    "inherits": "2.0.3",
-                    "pump": "2.0.1"
+                    "duplexify": "^3.5.3",
+                    "inherits": "^2.0.3",
+                    "pump": "^2.0.0"
                   }
                 },
                 "stream-each": {
                   "version": "1.2.2",
                   "bundled": true,
                   "requires": {
-                    "end-of-stream": "1.4.1",
-                    "stream-shift": "1.0.0"
+                    "end-of-stream": "^1.1.0",
+                    "stream-shift": "^1.0.0"
                   },
                   "dependencies": {
                     "stream-shift": {
@@ -2850,8 +2851,8 @@
                   "version": "2.0.3",
                   "bundled": true,
                   "requires": {
-                    "readable-stream": "2.3.6",
-                    "xtend": "4.0.1"
+                    "readable-stream": "^2.1.5",
+                    "xtend": "~4.0.1"
                   },
                   "dependencies": {
                     "xtend": {
@@ -2880,16 +2881,16 @@
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "3.0.1"
+            "string-width": "^2.0.0",
+            "strip-ansi": "^3.0.1"
           },
           "dependencies": {
             "string-width": {
               "version": "2.1.1",
               "bundled": true,
               "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
               },
               "dependencies": {
                 "is-fullwidth-code-point": {
@@ -2900,7 +2901,7 @@
                   "version": "4.0.0",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "3.0.0"
+                    "ansi-regex": "^3.0.0"
                   }
                 }
               }
@@ -2909,7 +2910,7 @@
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -2924,9 +2925,9 @@
           "version": "0.2.0",
           "bundled": true,
           "requires": {
-            "colors": "1.1.2",
-            "lodash": "3.10.1",
-            "string-width": "1.0.2"
+            "colors": "^1.1.2",
+            "lodash": "^3.10.1",
+            "string-width": "^1.0.1"
           },
           "dependencies": {
             "colors": {
@@ -2942,9 +2943,9 @@
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               },
               "dependencies": {
                 "code-point-at": {
@@ -2955,7 +2956,7 @@
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "number-is-nan": "1.0.1"
+                    "number-is-nan": "^1.0.0"
                   },
                   "dependencies": {
                     "number-is-nan": {
@@ -2968,7 +2969,7 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "2.1.1"
+                    "ansi-regex": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -2985,23 +2986,23 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1"
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "~0.5.0"
           }
         },
         "columnify": {
           "version": "1.5.4",
           "bundled": true,
           "requires": {
-            "strip-ansi": "3.0.1",
-            "wcwidth": "1.0.1"
+            "strip-ansi": "^3.0.0",
+            "wcwidth": "^1.0.0"
           },
           "dependencies": {
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -3014,14 +3015,14 @@
               "version": "1.0.1",
               "bundled": true,
               "requires": {
-                "defaults": "1.0.3"
+                "defaults": "^1.0.3"
               },
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
                   "bundled": true,
                   "requires": {
-                    "clone": "1.0.2"
+                    "clone": "^1.0.2"
                   },
                   "dependencies": {
                     "clone": {
@@ -3038,8 +3039,8 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "ini": "1.3.5",
-            "proto-list": "1.2.4"
+            "ini": "^1.3.4",
+            "proto-list": "~1.2.1"
           },
           "dependencies": {
             "proto-list": {
@@ -3064,8 +3065,8 @@
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "asap": "2.0.5",
-            "wrappy": "1.0.2"
+            "asap": "^2.0.0",
+            "wrappy": "1"
           },
           "dependencies": {
             "asap": {
@@ -3086,45 +3087,45 @@
           "version": "1.2.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "path-is-inside": "1.0.2",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "path-is-inside": "^1.0.1",
+            "rimraf": "^2.5.2"
           }
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "iferr": "0.1.5",
-            "imurmurhash": "0.1.4",
-            "readable-stream": "2.3.6"
+            "graceful-fs": "^4.1.2",
+            "iferr": "^0.1.5",
+            "imurmurhash": "^0.1.4",
+            "readable-stream": "1 || 2"
           }
         },
         "gentle-fs": {
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "fs-vacuum": "1.2.10",
-            "graceful-fs": "4.1.11",
-            "iferr": "0.1.5",
-            "mkdirp": "0.5.1",
-            "path-is-inside": "1.0.2",
-            "read-cmd-shim": "1.0.1",
-            "slide": "1.1.6"
+            "aproba": "^1.1.2",
+            "fs-vacuum": "^1.2.10",
+            "graceful-fs": "^4.1.11",
+            "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
+            "path-is-inside": "^1.0.2",
+            "read-cmd-shim": "^1.0.1",
+            "slide": "^1.1.6"
           }
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           },
           "dependencies": {
             "fs.realpath": {
@@ -3135,14 +3136,14 @@
               "version": "3.0.4",
               "bundled": true,
               "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.8",
                   "bundled": true,
                   "requires": {
-                    "balanced-match": "1.0.0",
+                    "balanced-match": "^1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -3188,8 +3189,8 @@
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -3204,21 +3205,21 @@
           "version": "1.10.3",
           "bundled": true,
           "requires": {
-            "glob": "7.1.2",
-            "npm-package-arg": "6.1.0",
-            "promzard": "0.3.0",
-            "read": "1.0.7",
-            "read-package-json": "2.0.13",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.3",
-            "validate-npm-package-name": "3.0.0"
+            "glob": "^7.1.1",
+            "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
+            "promzard": "^0.3.0",
+            "read": "~1.0.1",
+            "read-package-json": "1 || 2",
+            "semver": "2.x || 3.x || 4 || 5",
+            "validate-npm-package-license": "^3.0.1",
+            "validate-npm-package-name": "^3.0.0"
           },
           "dependencies": {
             "promzard": {
               "version": "0.3.0",
               "bundled": true,
               "requires": {
-                "read": "1.0.7"
+                "read": "1"
               }
             }
           }
@@ -3248,37 +3249,37 @@
           "version": "1.6.2",
           "bundled": true,
           "requires": {
-            "bin-links": "1.1.0",
-            "bluebird": "3.5.1",
-            "find-npm-prefix": "1.0.2",
-            "graceful-fs": "4.1.11",
-            "lock-verify": "2.0.1",
-            "npm-lifecycle": "2.0.1",
-            "npm-logical-tree": "1.2.1",
-            "npm-package-arg": "6.1.0",
-            "pacote": "7.6.1",
-            "protoduck": "5.0.0",
-            "read-package-json": "2.0.13",
-            "rimraf": "2.6.2",
-            "worker-farm": "1.6.0"
+            "bin-links": "^1.1.0",
+            "bluebird": "^3.5.1",
+            "find-npm-prefix": "^1.0.2",
+            "graceful-fs": "^4.1.11",
+            "lock-verify": "^2.0.0",
+            "npm-lifecycle": "^2.0.0",
+            "npm-logical-tree": "^1.2.1",
+            "npm-package-arg": "^6.0.0",
+            "pacote": "^7.5.1",
+            "protoduck": "^5.0.0",
+            "read-package-json": "^2.0.12",
+            "rimraf": "^2.6.2",
+            "worker-farm": "^1.5.4"
           },
           "dependencies": {
             "lock-verify": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "npm-package-arg": "5.1.2",
-                "semver": "5.5.0"
+                "npm-package-arg": "^5.1.2",
+                "semver": "^5.4.1"
               },
               "dependencies": {
                 "npm-package-arg": {
                   "version": "5.1.2",
                   "bundled": true,
                   "requires": {
-                    "hosted-git-info": "2.6.0",
-                    "osenv": "0.1.5",
-                    "semver": "5.5.0",
-                    "validate-npm-package-name": "3.0.0"
+                    "hosted-git-info": "^2.4.2",
+                    "osenv": "^0.1.4",
+                    "semver": "^5.1.0",
+                    "validate-npm-package-name": "^3.0.0"
                   }
                 }
               }
@@ -3291,7 +3292,7 @@
               "version": "5.0.0",
               "bundled": true,
               "requires": {
-                "genfun": "4.0.1"
+                "genfun": "^4.0.1"
               },
               "dependencies": {
                 "genfun": {
@@ -3306,14 +3307,14 @@
           "version": "10.2.0",
           "bundled": true,
           "requires": {
-            "dotenv": "5.0.1",
-            "npm-package-arg": "6.1.0",
-            "rimraf": "2.6.2",
-            "safe-buffer": "5.1.2",
-            "update-notifier": "2.5.0",
-            "which": "1.3.0",
-            "y18n": "4.0.0",
-            "yargs": "11.0.0"
+            "dotenv": "^5.0.1",
+            "npm-package-arg": "^6.0.0",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.0",
+            "update-notifier": "^2.3.0",
+            "which": "^1.3.0",
+            "y18n": "^4.0.0",
+            "yargs": "^11.0.0"
           },
           "dependencies": {
             "dotenv": {
@@ -3328,44 +3329,44 @@
               "version": "11.0.0",
               "bundled": true,
               "requires": {
-                "cliui": "4.1.0",
-                "decamelize": "1.2.0",
-                "find-up": "2.1.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "2.1.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.1",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "9.0.2"
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^9.0.2"
               },
               "dependencies": {
                 "cliui": {
                   "version": "4.1.0",
                   "bundled": true,
                   "requires": {
-                    "string-width": "2.1.1",
-                    "strip-ansi": "4.0.0",
-                    "wrap-ansi": "2.1.0"
+                    "string-width": "^2.1.1",
+                    "strip-ansi": "^4.0.0",
+                    "wrap-ansi": "^2.0.0"
                   },
                   "dependencies": {
                     "wrap-ansi": {
                       "version": "2.1.0",
                       "bundled": true,
                       "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1"
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1"
                       },
                       "dependencies": {
                         "string-width": {
                           "version": "1.0.2",
                           "bundled": true,
                           "requires": {
-                            "code-point-at": "1.1.0",
-                            "is-fullwidth-code-point": "1.0.0",
-                            "strip-ansi": "3.0.1"
+                            "code-point-at": "^1.0.0",
+                            "is-fullwidth-code-point": "^1.0.0",
+                            "strip-ansi": "^3.0.0"
                           },
                           "dependencies": {
                             "code-point-at": {
@@ -3376,7 +3377,7 @@
                               "version": "1.0.0",
                               "bundled": true,
                               "requires": {
-                                "number-is-nan": "1.0.1"
+                                "number-is-nan": "^1.0.0"
                               },
                               "dependencies": {
                                 "number-is-nan": {
@@ -3391,7 +3392,7 @@
                           "version": "3.0.1",
                           "bundled": true,
                           "requires": {
-                            "ansi-regex": "2.1.1"
+                            "ansi-regex": "^2.0.0"
                           },
                           "dependencies": {
                             "ansi-regex": {
@@ -3412,29 +3413,29 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "locate-path": "2.0.0"
+                    "locate-path": "^2.0.0"
                   },
                   "dependencies": {
                     "locate-path": {
                       "version": "2.0.0",
                       "bundled": true,
                       "requires": {
-                        "p-locate": "2.0.0",
-                        "path-exists": "3.0.0"
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
                       },
                       "dependencies": {
                         "p-locate": {
                           "version": "2.0.0",
                           "bundled": true,
                           "requires": {
-                            "p-limit": "1.2.0"
+                            "p-limit": "^1.1.0"
                           },
                           "dependencies": {
                             "p-limit": {
                               "version": "1.2.0",
                               "bundled": true,
                               "requires": {
-                                "p-try": "1.0.0"
+                                "p-try": "^1.0.0"
                               },
                               "dependencies": {
                                 "p-try": {
@@ -3461,38 +3462,38 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "execa": "0.7.0",
-                    "lcid": "1.0.0",
-                    "mem": "1.1.0"
+                    "execa": "^0.7.0",
+                    "lcid": "^1.0.0",
+                    "mem": "^1.1.0"
                   },
                   "dependencies": {
                     "execa": {
                       "version": "0.7.0",
                       "bundled": true,
                       "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                       },
                       "dependencies": {
                         "cross-spawn": {
                           "version": "5.1.0",
                           "bundled": true,
                           "requires": {
-                            "lru-cache": "4.1.2",
-                            "shebang-command": "1.2.0",
-                            "which": "1.3.0"
+                            "lru-cache": "^4.0.1",
+                            "shebang-command": "^1.2.0",
+                            "which": "^1.2.9"
                           },
                           "dependencies": {
                             "shebang-command": {
                               "version": "1.2.0",
                               "bundled": true,
                               "requires": {
-                                "shebang-regex": "1.0.0"
+                                "shebang-regex": "^1.0.0"
                               },
                               "dependencies": {
                                 "shebang-regex": {
@@ -3515,7 +3516,7 @@
                           "version": "2.0.2",
                           "bundled": true,
                           "requires": {
-                            "path-key": "2.0.1"
+                            "path-key": "^2.0.0"
                           },
                           "dependencies": {
                             "path-key": {
@@ -3542,7 +3543,7 @@
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "invert-kv": "1.0.0"
+                        "invert-kv": "^1.0.0"
                       },
                       "dependencies": {
                         "invert-kv": {
@@ -3555,7 +3556,7 @@
                       "version": "1.1.0",
                       "bundled": true,
                       "requires": {
-                        "mimic-fn": "1.2.0"
+                        "mimic-fn": "^1.0.0"
                       },
                       "dependencies": {
                         "mimic-fn": {
@@ -3582,8 +3583,8 @@
                   "version": "2.1.1",
                   "bundled": true,
                   "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "4.0.0"
+                    "is-fullwidth-code-point": "^2.0.0",
+                    "strip-ansi": "^4.0.0"
                   },
                   "dependencies": {
                     "is-fullwidth-code-point": {
@@ -3604,7 +3605,7 @@
                   "version": "9.0.2",
                   "bundled": true,
                   "requires": {
-                    "camelcase": "4.1.0"
+                    "camelcase": "^4.1.0"
                   },
                   "dependencies": {
                     "camelcase": {
@@ -3621,15 +3622,15 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "6.1.0",
-            "semver": "5.5.0"
+            "npm-package-arg": "^5.1.2 || 6",
+            "semver": "^5.4.1"
           }
         },
         "lockfile": {
           "version": "1.0.4",
           "bundled": true,
           "requires": {
-            "signal-exit": "3.0.2"
+            "signal-exit": "^3.0.2"
           },
           "dependencies": {
             "signal-exit": {
@@ -3646,8 +3647,8 @@
           "version": "4.6.0",
           "bundled": true,
           "requires": {
-            "lodash._createset": "4.0.3",
-            "lodash._root": "3.0.1"
+            "lodash._createset": "~4.0.0",
+            "lodash._root": "~3.0.0"
           },
           "dependencies": {
             "lodash._createset": {
@@ -3672,7 +3673,7 @@
           "version": "3.1.2",
           "bundled": true,
           "requires": {
-            "lodash._getnative": "3.9.1"
+            "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._getnative": {
@@ -3703,8 +3704,8 @@
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           },
           "dependencies": {
             "pseudomap": {
@@ -3725,25 +3726,25 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "concat-stream": "1.6.1",
-            "duplexify": "3.5.4",
-            "end-of-stream": "1.4.1",
-            "flush-write-stream": "1.0.2",
-            "from2": "2.3.0",
-            "parallel-transform": "1.1.0",
-            "pump": "3.0.0",
-            "pumpify": "1.4.0",
-            "stream-each": "1.2.2",
-            "through2": "2.0.3"
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
           },
           "dependencies": {
             "concat-stream": {
               "version": "1.6.1",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
               },
               "dependencies": {
                 "typedarray": {
@@ -3756,10 +3757,10 @@
               "version": "3.5.4",
               "bundled": true,
               "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -3772,32 +3773,32 @@
               "version": "1.4.1",
               "bundled": true,
               "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
               }
             },
             "flush-write-stream": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.4"
               }
             },
             "from2": {
               "version": "2.3.0",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0"
               }
             },
             "parallel-transform": {
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "cyclist": "0.2.2",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "cyclist": "~0.2.2",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.1.5"
               },
               "dependencies": {
                 "cyclist": {
@@ -3810,25 +3811,25 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
               }
             },
             "pumpify": {
               "version": "1.4.0",
               "bundled": true,
               "requires": {
-                "duplexify": "3.5.4",
-                "inherits": "2.0.3",
-                "pump": "2.0.1"
+                "duplexify": "^3.5.3",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
               },
               "dependencies": {
                 "pump": {
                   "version": "2.0.1",
                   "bundled": true,
                   "requires": {
-                    "end-of-stream": "1.4.1",
-                    "once": "1.4.0"
+                    "end-of-stream": "^1.1.0",
+                    "once": "^1.3.1"
                   }
                 }
               }
@@ -3837,8 +3838,8 @@
               "version": "1.2.2",
               "bundled": true,
               "requires": {
-                "end-of-stream": "1.4.1",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.1.0",
+                "stream-shift": "^1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -3851,8 +3852,8 @@
               "version": "2.0.3",
               "bundled": true,
               "requires": {
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
               },
               "dependencies": {
                 "xtend": {
@@ -3880,31 +3881,31 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "copy-concurrently": "1.0.5",
-            "fs-write-stream-atomic": "1.0.10",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "run-queue": "1.0.3"
+            "aproba": "^1.1.1",
+            "copy-concurrently": "^1.0.0",
+            "fs-write-stream-atomic": "^1.0.8",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.3"
           },
           "dependencies": {
             "copy-concurrently": {
               "version": "1.0.5",
               "bundled": true,
               "requires": {
-                "aproba": "1.2.0",
-                "fs-write-stream-atomic": "1.0.10",
-                "iferr": "0.1.5",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "run-queue": "1.0.3"
+                "aproba": "^1.1.1",
+                "fs-write-stream-atomic": "^1.0.8",
+                "iferr": "^0.1.5",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.0"
               }
             },
             "run-queue": {
               "version": "1.0.3",
               "bundled": true,
               "requires": {
-                "aproba": "1.2.0"
+                "aproba": "^1.1.1"
               }
             }
           }
@@ -3913,43 +3914,43 @@
           "version": "3.6.2",
           "bundled": true,
           "requires": {
-            "fstream": "1.0.11",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "nopt": "3.0.6",
-            "npmlog": "4.1.2",
-            "osenv": "0.1.5",
-            "request": "2.85.0",
-            "rimraf": "2.6.2",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "which": "1.3.0"
+            "fstream": "^1.0.0",
+            "glob": "^7.0.3",
+            "graceful-fs": "^4.1.2",
+            "minimatch": "^3.0.2",
+            "mkdirp": "^0.5.0",
+            "nopt": "2 || 3",
+            "npmlog": "0 || 1 || 2 || 3 || 4",
+            "osenv": "0",
+            "request": "2",
+            "rimraf": "2",
+            "semver": "~5.3.0",
+            "tar": "^2.0.0",
+            "which": "1"
           },
           "dependencies": {
             "fstream": {
               "version": "1.0.11",
               "bundled": true,
               "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
               }
             },
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
               "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.11",
                   "bundled": true,
                   "requires": {
-                    "balanced-match": "1.0.0",
+                    "balanced-match": "^1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -3969,7 +3970,7 @@
               "version": "3.0.6",
               "bundled": true,
               "requires": {
-                "abbrev": "1.1.1"
+                "abbrev": "1"
               }
             },
             "semver": {
@@ -3980,16 +3981,16 @@
               "version": "2.2.1",
               "bundled": true,
               "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
               },
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.9",
                   "bundled": true,
                   "requires": {
-                    "inherits": "2.0.3"
+                    "inherits": "~2.0.0"
                   }
                 }
               }
@@ -4000,25 +4001,25 @@
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.6.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.3"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           },
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
               },
               "dependencies": {
                 "builtin-modules": {
@@ -4033,8 +4034,8 @@
           "version": "1.0.9",
           "bundled": true,
           "requires": {
-            "cli-table2": "0.2.0",
-            "console-control-strings": "1.1.0"
+            "cli-table2": "^0.2.0",
+            "console-control-strings": "^1.1.0"
           },
           "dependencies": {
             "console-control-strings": {
@@ -4051,21 +4052,21 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "semver": "5.5.0"
+            "semver": "^2.3.0 || 3.x || 4 || 5"
           }
         },
         "npm-lifecycle": {
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "byline": "5.0.0",
-            "graceful-fs": "4.1.11",
-            "node-gyp": "3.6.2",
-            "resolve-from": "4.0.0",
-            "slide": "1.1.6",
+            "byline": "^5.0.0",
+            "graceful-fs": "^4.1.11",
+            "node-gyp": "^3.6.2",
+            "resolve-from": "^4.0.0",
+            "slide": "^1.1.6",
             "uid-number": "0.0.6",
-            "umask": "1.1.0",
-            "which": "1.3.0"
+            "umask": "^1.1.0",
+            "which": "^1.3.0"
           },
           "dependencies": {
             "byline": {
@@ -4082,39 +4083,39 @@
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.6.0",
-            "osenv": "0.1.5",
-            "semver": "5.5.0",
-            "validate-npm-package-name": "3.0.0"
+            "hosted-git-info": "^2.6.0",
+            "osenv": "^0.1.5",
+            "semver": "^5.5.0",
+            "validate-npm-package-name": "^3.0.0"
           }
         },
         "npm-packlist": {
           "version": "1.1.10",
           "bundled": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           },
           "dependencies": {
             "ignore-walk": {
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "minimatch": "3.0.4"
+                "minimatch": "^3.0.4"
               },
               "dependencies": {
                 "minimatch": {
                   "version": "3.0.4",
                   "bundled": true,
                   "requires": {
-                    "brace-expansion": "1.1.8"
+                    "brace-expansion": "^1.1.7"
                   },
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.8",
                       "bundled": true,
                       "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                       },
                       "dependencies": {
@@ -4142,39 +4143,39 @@
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "make-fetch-happen": "2.6.0"
+            "aproba": "^1.1.2",
+            "make-fetch-happen": "^2.5.0"
           },
           "dependencies": {
             "make-fetch-happen": {
               "version": "2.6.0",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "3.3.0",
-                "cacache": "10.0.4",
-                "http-cache-semantics": "3.8.1",
-                "http-proxy-agent": "2.0.0",
-                "https-proxy-agent": "2.1.1",
-                "lru-cache": "4.1.2",
-                "mississippi": "1.3.1",
-                "node-fetch-npm": "2.0.2",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.1",
-                "ssri": "5.3.0"
+                "agentkeepalive": "^3.3.0",
+                "cacache": "^10.0.0",
+                "http-cache-semantics": "^3.8.0",
+                "http-proxy-agent": "^2.0.0",
+                "https-proxy-agent": "^2.1.0",
+                "lru-cache": "^4.1.1",
+                "mississippi": "^1.2.0",
+                "node-fetch-npm": "^2.0.2",
+                "promise-retry": "^1.1.1",
+                "socks-proxy-agent": "^3.0.1",
+                "ssri": "^5.0.0"
               },
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.3.0",
                   "bundled": true,
                   "requires": {
-                    "humanize-ms": "1.2.1"
+                    "humanize-ms": "^1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
                       "requires": {
-                        "ms": "2.1.1"
+                        "ms": "^2.0.0"
                       },
                       "dependencies": {
                         "ms": {
@@ -4193,22 +4194,22 @@
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "2.6.9"
+                    "agent-base": "4",
+                    "debug": "2"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -4238,22 +4239,22 @@
                   "version": "2.1.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "3.1.0"
+                    "agent-base": "^4.1.0",
+                    "debug": "^3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -4283,25 +4284,25 @@
                   "version": "1.3.1",
                   "bundled": true,
                   "requires": {
-                    "concat-stream": "1.6.0",
-                    "duplexify": "3.5.3",
-                    "end-of-stream": "1.4.1",
-                    "flush-write-stream": "1.0.2",
-                    "from2": "2.3.0",
-                    "parallel-transform": "1.1.0",
-                    "pump": "1.0.3",
-                    "pumpify": "1.4.0",
-                    "stream-each": "1.2.2",
-                    "through2": "2.0.3"
+                    "concat-stream": "^1.5.0",
+                    "duplexify": "^3.4.2",
+                    "end-of-stream": "^1.1.0",
+                    "flush-write-stream": "^1.0.0",
+                    "from2": "^2.1.0",
+                    "parallel-transform": "^1.1.0",
+                    "pump": "^1.0.0",
+                    "pumpify": "^1.3.3",
+                    "stream-each": "^1.1.0",
+                    "through2": "^2.0.0"
                   },
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.6.0",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6",
-                        "typedarray": "0.0.6"
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.2.2",
+                        "typedarray": "^0.0.6"
                       },
                       "dependencies": {
                         "typedarray": {
@@ -4314,10 +4315,10 @@
                       "version": "3.5.3",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6",
-                        "stream-shift": "1.0.0"
+                        "end-of-stream": "^1.0.0",
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0",
+                        "stream-shift": "^1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -4330,32 +4331,32 @@
                       "version": "1.4.1",
                       "bundled": true,
                       "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                       }
                     },
                     "flush-write-stream": {
                       "version": "1.0.2",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.4"
                       }
                     },
                     "from2": {
                       "version": "2.3.0",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0"
                       }
                     },
                     "parallel-transform": {
                       "version": "1.1.0",
                       "bundled": true,
                       "requires": {
-                        "cyclist": "0.2.2",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "cyclist": "~0.2.2",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.1.5"
                       },
                       "dependencies": {
                         "cyclist": {
@@ -4368,25 +4369,25 @@
                       "version": "1.0.3",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "once": "1.4.0"
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
                       }
                     },
                     "pumpify": {
                       "version": "1.4.0",
                       "bundled": true,
                       "requires": {
-                        "duplexify": "3.5.3",
-                        "inherits": "2.0.3",
-                        "pump": "2.0.1"
+                        "duplexify": "^3.5.3",
+                        "inherits": "^2.0.3",
+                        "pump": "^2.0.0"
                       },
                       "dependencies": {
                         "pump": {
                           "version": "2.0.1",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "1.4.1",
-                            "once": "1.4.0"
+                            "end-of-stream": "^1.1.0",
+                            "once": "^1.3.1"
                           }
                         }
                       }
@@ -4395,8 +4396,8 @@
                       "version": "1.2.2",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "stream-shift": "1.0.0"
+                        "end-of-stream": "^1.1.0",
+                        "stream-shift": "^1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -4409,8 +4410,8 @@
                       "version": "2.0.3",
                       "bundled": true,
                       "requires": {
-                        "readable-stream": "2.3.6",
-                        "xtend": "4.0.1"
+                        "readable-stream": "^2.1.5",
+                        "xtend": "~4.0.1"
                       },
                       "dependencies": {
                         "xtend": {
@@ -4425,16 +4426,16 @@
                   "version": "2.0.2",
                   "bundled": true,
                   "requires": {
-                    "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.1",
-                    "safe-buffer": "5.1.2"
+                    "encoding": "^0.1.11",
+                    "json-parse-better-errors": "^1.0.0",
+                    "safe-buffer": "^5.1.1"
                   },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
                       "requires": {
-                        "iconv-lite": "0.4.19"
+                        "iconv-lite": "~0.4.13"
                       },
                       "dependencies": {
                         "iconv-lite": {
@@ -4453,8 +4454,8 @@
                   "version": "1.1.1",
                   "bundled": true,
                   "requires": {
-                    "err-code": "1.1.2",
-                    "retry": "0.10.1"
+                    "err-code": "^1.0.0",
+                    "retry": "^0.10.0"
                   },
                   "dependencies": {
                     "err-code": {
@@ -4471,22 +4472,22 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "socks": "1.1.10"
+                    "agent-base": "^4.1.0",
+                    "socks": "^1.1.10"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -4501,8 +4502,8 @@
                       "version": "1.1.10",
                       "bundled": true,
                       "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "1.1.15"
+                        "ip": "^1.1.4",
+                        "smart-buffer": "^1.0.13"
                       },
                       "dependencies": {
                         "ip": {
@@ -4525,27 +4526,27 @@
           "version": "8.5.1",
           "bundled": true,
           "requires": {
-            "concat-stream": "1.6.1",
-            "graceful-fs": "4.1.11",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "6.1.0",
-            "npmlog": "4.1.2",
-            "once": "1.4.0",
-            "request": "2.85.0",
-            "retry": "0.10.1",
-            "safe-buffer": "5.1.2",
-            "semver": "5.5.0",
-            "slide": "1.1.6",
-            "ssri": "5.3.0"
+            "concat-stream": "^1.5.2",
+            "graceful-fs": "^4.1.6",
+            "normalize-package-data": "~1.0.1 || ^2.0.0",
+            "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+            "npmlog": "2 || ^3.1.0 || ^4.0.0",
+            "once": "^1.3.3",
+            "request": "^2.74.0",
+            "retry": "^0.10.0",
+            "safe-buffer": "^5.1.1",
+            "semver": "2 >=2.2.1 || 3.x || 4 || 5",
+            "slide": "^1.1.3",
+            "ssri": "^5.2.4"
           },
           "dependencies": {
             "concat-stream": {
               "version": "1.6.1",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
               },
               "dependencies": {
                 "typedarray": {
@@ -4564,12 +4565,12 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "figgy-pudding": "2.0.1",
-            "lru-cache": "4.1.2",
-            "make-fetch-happen": "3.0.0",
-            "npm-package-arg": "6.1.0",
-            "safe-buffer": "5.1.2"
+            "bluebird": "^3.5.1",
+            "figgy-pudding": "^2.0.1",
+            "lru-cache": "^4.1.2",
+            "make-fetch-happen": "^3.0.0",
+            "npm-package-arg": "^6.0.0",
+            "safe-buffer": "^5.1.1"
           },
           "dependencies": {
             "figgy-pudding": {
@@ -4580,31 +4581,31 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "3.4.1",
-                "cacache": "10.0.4",
-                "http-cache-semantics": "3.8.1",
-                "http-proxy-agent": "2.1.0",
-                "https-proxy-agent": "2.2.1",
-                "lru-cache": "4.1.2",
-                "mississippi": "3.0.0",
-                "node-fetch-npm": "2.0.2",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.1",
-                "ssri": "5.3.0"
+                "agentkeepalive": "^3.4.1",
+                "cacache": "^10.0.4",
+                "http-cache-semantics": "^3.8.1",
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.0",
+                "lru-cache": "^4.1.2",
+                "mississippi": "^3.0.0",
+                "node-fetch-npm": "^2.0.2",
+                "promise-retry": "^1.1.1",
+                "socks-proxy-agent": "^3.0.1",
+                "ssri": "^5.2.4"
               },
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.4.1",
                   "bundled": true,
                   "requires": {
-                    "humanize-ms": "1.2.1"
+                    "humanize-ms": "^1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
                       "requires": {
-                        "ms": "2.1.1"
+                        "ms": "^2.0.0"
                       },
                       "dependencies": {
                         "ms": {
@@ -4623,7 +4624,7 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
+                    "agent-base": "4",
                     "debug": "3.1.0"
                   },
                   "dependencies": {
@@ -4631,14 +4632,14 @@
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -4668,22 +4669,22 @@
                   "version": "2.2.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "3.1.0"
+                    "agent-base": "^4.1.0",
+                    "debug": "^3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -4713,23 +4714,23 @@
                   "version": "2.0.2",
                   "bundled": true,
                   "requires": {
-                    "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.2",
-                    "safe-buffer": "5.1.2"
+                    "encoding": "^0.1.11",
+                    "json-parse-better-errors": "^1.0.0",
+                    "safe-buffer": "^5.1.1"
                   },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
                       "requires": {
-                        "iconv-lite": "0.4.21"
+                        "iconv-lite": "~0.4.13"
                       },
                       "dependencies": {
                         "iconv-lite": {
                           "version": "0.4.21",
                           "bundled": true,
                           "requires": {
-                            "safer-buffer": "2.1.2"
+                            "safer-buffer": "^2.1.0"
                           },
                           "dependencies": {
                             "safer-buffer": {
@@ -4746,8 +4747,8 @@
                   "version": "1.1.1",
                   "bundled": true,
                   "requires": {
-                    "err-code": "1.1.2",
-                    "retry": "0.10.1"
+                    "err-code": "^1.0.0",
+                    "retry": "^0.10.0"
                   },
                   "dependencies": {
                     "err-code": {
@@ -4764,22 +4765,22 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "socks": "1.1.10"
+                    "agent-base": "^4.1.0",
+                    "socks": "^1.1.10"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -4794,8 +4795,8 @@
                       "version": "1.1.10",
                       "bundled": true,
                       "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "1.1.15"
+                        "ip": "^1.1.4",
+                        "smart-buffer": "^1.0.13"
                       },
                       "dependencies": {
                         "ip": {
@@ -4822,18 +4823,18 @@
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           },
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.1.4",
               "bundled": true,
               "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.6"
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
               },
               "dependencies": {
                 "delegates": {
@@ -4850,14 +4851,14 @@
               "version": "2.7.4",
               "bundled": true,
               "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
               },
               "dependencies": {
                 "object-assign": {
@@ -4872,9 +4873,9 @@
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
                   },
                   "dependencies": {
                     "code-point-at": {
@@ -4885,7 +4886,7 @@
                       "version": "1.0.0",
                       "bundled": true,
                       "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                       },
                       "dependencies": {
                         "number-is-nan": {
@@ -4900,7 +4901,7 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "2.1.1"
+                    "ansi-regex": "^2.0.0"
                   },
                   "dependencies": {
                     "ansi-regex": {
@@ -4913,7 +4914,7 @@
                   "version": "1.1.2",
                   "bundled": true,
                   "requires": {
-                    "string-width": "1.0.2"
+                    "string-width": "^1.0.2"
                   }
                 }
               }
@@ -4928,7 +4929,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "opener": {
@@ -4939,8 +4940,8 @@
           "version": "0.1.5",
           "bundled": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           },
           "dependencies": {
             "os-homedir": {
@@ -4957,30 +4958,30 @@
           "version": "7.6.1",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.1",
-            "cacache": "10.0.4",
-            "get-stream": "3.0.0",
-            "glob": "7.1.2",
-            "lru-cache": "4.1.2",
-            "make-fetch-happen": "2.6.0",
-            "minimatch": "3.0.4",
-            "mississippi": "3.0.0",
-            "mkdirp": "0.5.1",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "6.1.0",
-            "npm-packlist": "1.1.10",
-            "npm-pick-manifest": "2.1.0",
-            "osenv": "0.1.5",
-            "promise-inflight": "1.0.1",
-            "promise-retry": "1.1.1",
-            "protoduck": "5.0.0",
-            "rimraf": "2.6.2",
-            "safe-buffer": "5.1.2",
-            "semver": "5.5.0",
-            "ssri": "5.3.0",
-            "tar": "4.4.2",
-            "unique-filename": "1.1.0",
-            "which": "1.3.0"
+            "bluebird": "^3.5.1",
+            "cacache": "^10.0.4",
+            "get-stream": "^3.0.0",
+            "glob": "^7.1.2",
+            "lru-cache": "^4.1.1",
+            "make-fetch-happen": "^2.6.0",
+            "minimatch": "^3.0.4",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "normalize-package-data": "^2.4.0",
+            "npm-package-arg": "^6.0.0",
+            "npm-packlist": "^1.1.10",
+            "npm-pick-manifest": "^2.1.0",
+            "osenv": "^0.1.5",
+            "promise-inflight": "^1.0.1",
+            "promise-retry": "^1.1.1",
+            "protoduck": "^5.0.0",
+            "rimraf": "^2.6.2",
+            "safe-buffer": "^5.1.1",
+            "semver": "^5.5.0",
+            "ssri": "^5.2.4",
+            "tar": "^4.4.0",
+            "unique-filename": "^1.1.0",
+            "which": "^1.3.0"
           },
           "dependencies": {
             "get-stream": {
@@ -4991,31 +4992,31 @@
               "version": "2.6.0",
               "bundled": true,
               "requires": {
-                "agentkeepalive": "3.4.0",
-                "cacache": "10.0.4",
-                "http-cache-semantics": "3.8.1",
-                "http-proxy-agent": "2.1.0",
-                "https-proxy-agent": "2.2.0",
-                "lru-cache": "4.1.2",
-                "mississippi": "1.3.1",
-                "node-fetch-npm": "2.0.2",
-                "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.1",
-                "ssri": "5.3.0"
+                "agentkeepalive": "^3.3.0",
+                "cacache": "^10.0.0",
+                "http-cache-semantics": "^3.8.0",
+                "http-proxy-agent": "^2.0.0",
+                "https-proxy-agent": "^2.1.0",
+                "lru-cache": "^4.1.1",
+                "mississippi": "^1.2.0",
+                "node-fetch-npm": "^2.0.2",
+                "promise-retry": "^1.1.1",
+                "socks-proxy-agent": "^3.0.1",
+                "ssri": "^5.0.0"
               },
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.4.0",
                   "bundled": true,
                   "requires": {
-                    "humanize-ms": "1.2.1"
+                    "humanize-ms": "^1.2.1"
                   },
                   "dependencies": {
                     "humanize-ms": {
                       "version": "1.2.1",
                       "bundled": true,
                       "requires": {
-                        "ms": "2.1.1"
+                        "ms": "^2.0.0"
                       },
                       "dependencies": {
                         "ms": {
@@ -5034,7 +5035,7 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
+                    "agent-base": "4",
                     "debug": "3.1.0"
                   },
                   "dependencies": {
@@ -5042,14 +5043,14 @@
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -5079,22 +5080,22 @@
                   "version": "2.2.0",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "debug": "3.1.0"
+                    "agent-base": "^4.1.0",
+                    "debug": "^3.1.0"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -5124,25 +5125,25 @@
                   "version": "1.3.1",
                   "bundled": true,
                   "requires": {
-                    "concat-stream": "1.6.1",
-                    "duplexify": "3.5.4",
-                    "end-of-stream": "1.4.1",
-                    "flush-write-stream": "1.0.2",
-                    "from2": "2.3.0",
-                    "parallel-transform": "1.1.0",
-                    "pump": "1.0.3",
-                    "pumpify": "1.4.0",
-                    "stream-each": "1.2.2",
-                    "through2": "2.0.3"
+                    "concat-stream": "^1.5.0",
+                    "duplexify": "^3.4.2",
+                    "end-of-stream": "^1.1.0",
+                    "flush-write-stream": "^1.0.0",
+                    "from2": "^2.1.0",
+                    "parallel-transform": "^1.1.0",
+                    "pump": "^1.0.0",
+                    "pumpify": "^1.3.3",
+                    "stream-each": "^1.1.0",
+                    "through2": "^2.0.0"
                   },
                   "dependencies": {
                     "concat-stream": {
                       "version": "1.6.1",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6",
-                        "typedarray": "0.0.6"
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.2.2",
+                        "typedarray": "^0.0.6"
                       },
                       "dependencies": {
                         "typedarray": {
@@ -5155,10 +5156,10 @@
                       "version": "3.5.4",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6",
-                        "stream-shift": "1.0.0"
+                        "end-of-stream": "^1.0.0",
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0",
+                        "stream-shift": "^1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -5171,32 +5172,32 @@
                       "version": "1.4.1",
                       "bundled": true,
                       "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                       }
                     },
                     "flush-write-stream": {
                       "version": "1.0.2",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.4"
                       }
                     },
                     "from2": {
                       "version": "2.3.0",
                       "bundled": true,
                       "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.0"
                       }
                     },
                     "parallel-transform": {
                       "version": "1.1.0",
                       "bundled": true,
                       "requires": {
-                        "cyclist": "0.2.2",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.3.6"
+                        "cyclist": "~0.2.2",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^2.1.5"
                       },
                       "dependencies": {
                         "cyclist": {
@@ -5209,25 +5210,25 @@
                       "version": "1.0.3",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "once": "1.4.0"
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
                       }
                     },
                     "pumpify": {
                       "version": "1.4.0",
                       "bundled": true,
                       "requires": {
-                        "duplexify": "3.5.4",
-                        "inherits": "2.0.3",
-                        "pump": "2.0.1"
+                        "duplexify": "^3.5.3",
+                        "inherits": "^2.0.3",
+                        "pump": "^2.0.0"
                       },
                       "dependencies": {
                         "pump": {
                           "version": "2.0.1",
                           "bundled": true,
                           "requires": {
-                            "end-of-stream": "1.4.1",
-                            "once": "1.4.0"
+                            "end-of-stream": "^1.1.0",
+                            "once": "^1.3.1"
                           }
                         }
                       }
@@ -5236,8 +5237,8 @@
                       "version": "1.2.2",
                       "bundled": true,
                       "requires": {
-                        "end-of-stream": "1.4.1",
-                        "stream-shift": "1.0.0"
+                        "end-of-stream": "^1.1.0",
+                        "stream-shift": "^1.0.0"
                       },
                       "dependencies": {
                         "stream-shift": {
@@ -5250,8 +5251,8 @@
                       "version": "2.0.3",
                       "bundled": true,
                       "requires": {
-                        "readable-stream": "2.3.6",
-                        "xtend": "4.0.1"
+                        "readable-stream": "^2.1.5",
+                        "xtend": "~4.0.1"
                       },
                       "dependencies": {
                         "xtend": {
@@ -5266,16 +5267,16 @@
                   "version": "2.0.2",
                   "bundled": true,
                   "requires": {
-                    "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.1",
-                    "safe-buffer": "5.1.2"
+                    "encoding": "^0.1.11",
+                    "json-parse-better-errors": "^1.0.0",
+                    "safe-buffer": "^5.1.1"
                   },
                   "dependencies": {
                     "encoding": {
                       "version": "0.1.12",
                       "bundled": true,
                       "requires": {
-                        "iconv-lite": "0.4.19"
+                        "iconv-lite": "~0.4.13"
                       },
                       "dependencies": {
                         "iconv-lite": {
@@ -5294,22 +5295,22 @@
                   "version": "3.0.1",
                   "bundled": true,
                   "requires": {
-                    "agent-base": "4.2.0",
-                    "socks": "1.1.10"
+                    "agent-base": "^4.1.0",
+                    "socks": "^1.1.10"
                   },
                   "dependencies": {
                     "agent-base": {
                       "version": "4.2.0",
                       "bundled": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "es6-promisify": "^5.0.0"
                       },
                       "dependencies": {
                         "es6-promisify": {
                           "version": "5.0.0",
                           "bundled": true,
                           "requires": {
-                            "es6-promise": "4.2.4"
+                            "es6-promise": "^4.0.3"
                           },
                           "dependencies": {
                             "es6-promise": {
@@ -5324,8 +5325,8 @@
                       "version": "1.1.10",
                       "bundled": true,
                       "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "1.1.15"
+                        "ip": "^1.1.4",
+                        "smart-buffer": "^1.0.13"
                       },
                       "dependencies": {
                         "ip": {
@@ -5346,14 +5347,14 @@
               "version": "3.0.4",
               "bundled": true,
               "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
               },
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.11",
                   "bundled": true,
                   "requires": {
-                    "balanced-match": "1.0.0",
+                    "balanced-match": "^1.0.0",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
@@ -5373,16 +5374,16 @@
               "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "npm-package-arg": "6.1.0",
-                "semver": "5.5.0"
+                "npm-package-arg": "^6.0.0",
+                "semver": "^5.4.1"
               }
             },
             "promise-retry": {
               "version": "1.1.1",
               "bundled": true,
               "requires": {
-                "err-code": "1.1.2",
-                "retry": "0.10.1"
+                "err-code": "^1.0.0",
+                "retry": "^0.10.0"
               },
               "dependencies": {
                 "err-code": {
@@ -5399,7 +5400,7 @@
               "version": "5.0.0",
               "bundled": true,
               "requires": {
-                "genfun": "4.0.1"
+                "genfun": "^4.0.1"
               },
               "dependencies": {
                 "genfun": {
@@ -5426,8 +5427,8 @@
           "version": "6.1.0",
           "bundled": true,
           "requires": {
-            "decode-uri-component": "0.2.0",
-            "strict-uri-encode": "2.0.0"
+            "decode-uri-component": "^0.2.0",
+            "strict-uri-encode": "^2.0.0"
           },
           "dependencies": {
             "decode-uri-component": {
@@ -5448,7 +5449,7 @@
           "version": "1.0.7",
           "bundled": true,
           "requires": {
-            "mute-stream": "0.0.7"
+            "mute-stream": "~0.0.4"
           },
           "dependencies": {
             "mute-stream": {
@@ -5461,20 +5462,20 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.2"
           }
         },
         "read-installed": {
           "version": "4.0.3",
           "bundled": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "graceful-fs": "4.1.11",
-            "read-package-json": "2.0.13",
-            "readdir-scoped-modules": "1.0.2",
-            "semver": "5.5.0",
-            "slide": "1.1.6",
-            "util-extend": "1.0.3"
+            "debuglog": "^1.0.1",
+            "graceful-fs": "^4.1.2",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "slide": "~1.1.3",
+            "util-extend": "^1.0.1"
           },
           "dependencies": {
             "util-extend": {
@@ -5487,11 +5488,11 @@
           "version": "2.0.13",
           "bundled": true,
           "requires": {
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "json-parse-better-errors": "1.0.1",
-            "normalize-package-data": "2.4.0",
-            "slash": "1.0.0"
+            "glob": "^7.1.1",
+            "graceful-fs": "^4.1.2",
+            "json-parse-better-errors": "^1.0.1",
+            "normalize-package-data": "^2.0.0",
+            "slash": "^1.0.0"
           },
           "dependencies": {
             "json-parse-better-errors": {
@@ -5508,24 +5509,24 @@
           "version": "5.2.1",
           "bundled": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "once": "1.4.0",
-            "read-package-json": "2.0.13",
-            "readdir-scoped-modules": "1.0.2"
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "once": "^1.3.0",
+            "read-package-json": "^2.0.0",
+            "readdir-scoped-modules": "^1.0.0"
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           },
           "dependencies": {
             "core-util-is": {
@@ -5544,7 +5545,7 @@
               "version": "1.1.1",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
               }
             },
             "util-deprecate": {
@@ -5557,38 +5558,38 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "debuglog": "1.0.1",
-            "dezalgo": "1.0.3",
-            "graceful-fs": "4.1.11",
-            "once": "1.4.0"
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "graceful-fs": "^4.1.2",
+            "once": "^1.3.0"
           }
         },
         "request": {
           "version": "2.85.0",
           "bundled": true,
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "hawk": "~6.0.2",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "stringstream": "~0.0.5",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
           },
           "dependencies": {
             "aws-sign2": {
@@ -5607,7 +5608,7 @@
               "version": "1.0.6",
               "bundled": true,
               "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
               },
               "dependencies": {
                 "delayed-stream": {
@@ -5628,9 +5629,9 @@
               "version": "2.3.2",
               "bundled": true,
               "requires": {
-                "asynckit": "0.4.0",
+                "asynckit": "^0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
+                "mime-types": "^2.1.12"
               },
               "dependencies": {
                 "asynckit": {
@@ -5643,18 +5644,18 @@
               "version": "5.0.3",
               "bundled": true,
               "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
+                "ajv": "^5.1.0",
+                "har-schema": "^2.0.0"
               },
               "dependencies": {
                 "ajv": {
                   "version": "5.5.2",
                   "bundled": true,
                   "requires": {
-                    "co": "4.6.0",
-                    "fast-deep-equal": "1.1.0",
-                    "fast-json-stable-stringify": "2.0.0",
-                    "json-schema-traverse": "0.3.1"
+                    "co": "^4.6.0",
+                    "fast-deep-equal": "^1.0.0",
+                    "fast-json-stable-stringify": "^2.0.0",
+                    "json-schema-traverse": "^0.3.0"
                   },
                   "dependencies": {
                     "co": {
@@ -5685,31 +5686,31 @@
               "version": "6.0.2",
               "bundled": true,
               "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.1",
-                "sntp": "2.1.0"
+                "boom": "4.x.x",
+                "cryptiles": "3.x.x",
+                "hoek": "4.x.x",
+                "sntp": "2.x.x"
               },
               "dependencies": {
                 "boom": {
                   "version": "4.3.1",
                   "bundled": true,
                   "requires": {
-                    "hoek": "4.2.1"
+                    "hoek": "4.x.x"
                   }
                 },
                 "cryptiles": {
                   "version": "3.1.2",
                   "bundled": true,
                   "requires": {
-                    "boom": "5.2.0"
+                    "boom": "5.x.x"
                   },
                   "dependencies": {
                     "boom": {
                       "version": "5.2.0",
                       "bundled": true,
                       "requires": {
-                        "hoek": "4.2.1"
+                        "hoek": "4.x.x"
                       }
                     }
                   }
@@ -5722,7 +5723,7 @@
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "hoek": "4.2.1"
+                    "hoek": "4.x.x"
                   }
                 }
               }
@@ -5731,9 +5732,9 @@
               "version": "1.2.0",
               "bundled": true,
               "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.1"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -5762,9 +5763,9 @@
                       "version": "1.10.0",
                       "bundled": true,
                       "requires": {
-                        "assert-plus": "1.0.0",
+                        "assert-plus": "^1.0.0",
                         "core-util-is": "1.0.2",
-                        "extsprintf": "1.3.0"
+                        "extsprintf": "^1.2.0"
                       },
                       "dependencies": {
                         "core-util-is": {
@@ -5779,14 +5780,14 @@
                   "version": "1.14.1",
                   "bundled": true,
                   "requires": {
-                    "asn1": "0.2.3",
-                    "assert-plus": "1.0.0",
-                    "bcrypt-pbkdf": "1.0.1",
-                    "dashdash": "1.14.1",
-                    "ecc-jsbn": "0.1.1",
-                    "getpass": "0.1.7",
-                    "jsbn": "0.1.1",
-                    "tweetnacl": "0.14.5"
+                    "asn1": "~0.2.3",
+                    "assert-plus": "^1.0.0",
+                    "bcrypt-pbkdf": "^1.0.0",
+                    "dashdash": "^1.12.0",
+                    "ecc-jsbn": "~0.1.1",
+                    "getpass": "^0.1.1",
+                    "jsbn": "~0.1.0",
+                    "tweetnacl": "~0.14.0"
                   },
                   "dependencies": {
                     "asn1": {
@@ -5798,14 +5799,14 @@
                       "bundled": true,
                       "optional": true,
                       "requires": {
-                        "tweetnacl": "0.14.5"
+                        "tweetnacl": "^0.14.3"
                       }
                     },
                     "dashdash": {
                       "version": "1.14.1",
                       "bundled": true,
                       "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                       }
                     },
                     "ecc-jsbn": {
@@ -5813,14 +5814,14 @@
                       "bundled": true,
                       "optional": true,
                       "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "~0.1.0"
                       }
                     },
                     "getpass": {
                       "version": "0.1.7",
                       "bundled": true,
                       "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                       }
                     },
                     "jsbn": {
@@ -5853,7 +5854,7 @@
               "version": "2.1.18",
               "bundled": true,
               "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": "~1.33.0"
               },
               "dependencies": {
                 "mime-db": {
@@ -5882,7 +5883,7 @@
               "version": "2.3.4",
               "bundled": true,
               "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
               },
               "dependencies": {
                 "punycode": {
@@ -5895,7 +5896,7 @@
               "version": "0.6.0",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
               }
             }
           }
@@ -5908,7 +5909,7 @@
           "version": "2.6.2",
           "bundled": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -5923,8 +5924,8 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "readable-stream": "2.3.6"
+            "graceful-fs": "^4.1.2",
+            "readable-stream": "^2.0.2"
           }
         },
         "slide": {
@@ -5939,26 +5940,26 @@
           "version": "2.1.3",
           "bundled": true,
           "requires": {
-            "from2": "1.3.0",
-            "stream-iterate": "1.2.0"
+            "from2": "^1.3.0",
+            "stream-iterate": "^1.1.0"
           },
           "dependencies": {
             "from2": {
               "version": "1.3.0",
               "bundled": true,
               "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "1.1.14"
+                "inherits": "~2.0.1",
+                "readable-stream": "~1.1.10"
               },
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.14",
                   "bundled": true,
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
                     "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
+                    "string_decoder": "~0.10.x"
                   },
                   "dependencies": {
                     "core-util-is": {
@@ -5981,8 +5982,8 @@
               "version": "1.2.0",
               "bundled": true,
               "requires": {
-                "readable-stream": "2.3.6",
-                "stream-shift": "1.0.0"
+                "readable-stream": "^2.1.5",
+                "stream-shift": "^1.0.0"
               },
               "dependencies": {
                 "stream-shift": {
@@ -5997,14 +5998,14 @@
           "version": "5.3.0",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "^5.1.1"
           }
         },
         "strip-ansi": {
           "version": "4.0.0",
           "bundled": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -6017,35 +6018,35 @@
           "version": "4.4.2",
           "bundled": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
           },
           "dependencies": {
             "fs-minipass": {
               "version": "1.2.5",
               "bundled": true,
               "requires": {
-                "minipass": "2.2.4"
+                "minipass": "^2.2.1"
               }
             },
             "minipass": {
               "version": "2.2.4",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.2",
-                "yallist": "3.0.2"
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.0"
               }
             },
             "minizlib": {
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "minipass": "2.2.4"
+                "minipass": "^2.2.1"
               }
             },
             "safe-buffer": {
@@ -6078,14 +6079,14 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "unique-slug": "2.0.0"
+            "unique-slug": "^2.0.0"
           },
           "dependencies": {
             "unique-slug": {
               "version": "2.0.0",
               "bundled": true,
               "requires": {
-                "imurmurhash": "0.1.4"
+                "imurmurhash": "^0.1.4"
               }
             }
           }
@@ -6098,36 +6099,36 @@
           "version": "2.5.0",
           "bundled": true,
           "requires": {
-            "boxen": "1.3.0",
-            "chalk": "2.4.1",
-            "configstore": "3.1.2",
-            "import-lazy": "2.1.0",
-            "is-ci": "1.1.0",
-            "is-installed-globally": "0.1.0",
-            "is-npm": "1.0.0",
-            "latest-version": "3.1.0",
-            "semver-diff": "2.1.0",
-            "xdg-basedir": "3.0.0"
+            "boxen": "^1.2.1",
+            "chalk": "^2.0.1",
+            "configstore": "^3.0.0",
+            "import-lazy": "^2.1.0",
+            "is-ci": "^1.0.10",
+            "is-installed-globally": "^0.1.0",
+            "is-npm": "^1.0.0",
+            "latest-version": "^3.0.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
           },
           "dependencies": {
             "boxen": {
               "version": "1.3.0",
               "bundled": true,
               "requires": {
-                "ansi-align": "2.0.0",
-                "camelcase": "4.1.0",
-                "chalk": "2.4.1",
-                "cli-boxes": "1.0.0",
-                "string-width": "2.1.1",
-                "term-size": "1.2.0",
-                "widest-line": "2.0.0"
+                "ansi-align": "^2.0.0",
+                "camelcase": "^4.0.0",
+                "chalk": "^2.0.1",
+                "cli-boxes": "^1.0.0",
+                "string-width": "^2.0.0",
+                "term-size": "^1.2.0",
+                "widest-line": "^2.0.0"
               },
               "dependencies": {
                 "ansi-align": {
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "string-width": "2.1.1"
+                    "string-width": "^2.0.0"
                   }
                 },
                 "camelcase": {
@@ -6142,8 +6143,8 @@
                   "version": "2.1.1",
                   "bundled": true,
                   "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "4.0.0"
+                    "is-fullwidth-code-point": "^2.0.0",
+                    "strip-ansi": "^4.0.0"
                   },
                   "dependencies": {
                     "is-fullwidth-code-point": {
@@ -6156,36 +6157,36 @@
                   "version": "1.2.0",
                   "bundled": true,
                   "requires": {
-                    "execa": "0.7.0"
+                    "execa": "^0.7.0"
                   },
                   "dependencies": {
                     "execa": {
                       "version": "0.7.0",
                       "bundled": true,
                       "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                       },
                       "dependencies": {
                         "cross-spawn": {
                           "version": "5.1.0",
                           "bundled": true,
                           "requires": {
-                            "lru-cache": "4.1.2",
-                            "shebang-command": "1.2.0",
-                            "which": "1.3.0"
+                            "lru-cache": "^4.0.1",
+                            "shebang-command": "^1.2.0",
+                            "which": "^1.2.9"
                           },
                           "dependencies": {
                             "shebang-command": {
                               "version": "1.2.0",
                               "bundled": true,
                               "requires": {
-                                "shebang-regex": "1.0.0"
+                                "shebang-regex": "^1.0.0"
                               },
                               "dependencies": {
                                 "shebang-regex": {
@@ -6208,7 +6209,7 @@
                           "version": "2.0.2",
                           "bundled": true,
                           "requires": {
-                            "path-key": "2.0.1"
+                            "path-key": "^2.0.0"
                           },
                           "dependencies": {
                             "path-key": {
@@ -6237,7 +6238,7 @@
                   "version": "2.0.0",
                   "bundled": true,
                   "requires": {
-                    "string-width": "2.1.1"
+                    "string-width": "^2.1.1"
                   }
                 }
               }
@@ -6246,23 +6247,23 @@
               "version": "2.4.1",
               "bundled": true,
               "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.4.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
               },
               "dependencies": {
                 "ansi-styles": {
                   "version": "3.2.1",
                   "bundled": true,
                   "requires": {
-                    "color-convert": "1.9.1"
+                    "color-convert": "^1.9.0"
                   },
                   "dependencies": {
                     "color-convert": {
                       "version": "1.9.1",
                       "bundled": true,
                       "requires": {
-                        "color-name": "1.1.3"
+                        "color-name": "^1.1.1"
                       },
                       "dependencies": {
                         "color-name": {
@@ -6281,7 +6282,7 @@
                   "version": "5.4.0",
                   "bundled": true,
                   "requires": {
-                    "has-flag": "3.0.0"
+                    "has-flag": "^3.0.0"
                   },
                   "dependencies": {
                     "has-flag": {
@@ -6296,19 +6297,19 @@
               "version": "3.1.2",
               "bundled": true,
               "requires": {
-                "dot-prop": "4.2.0",
-                "graceful-fs": "4.1.11",
-                "make-dir": "1.2.0",
-                "unique-string": "1.0.0",
-                "write-file-atomic": "2.3.0",
-                "xdg-basedir": "3.0.0"
+                "dot-prop": "^4.1.0",
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^1.0.0",
+                "unique-string": "^1.0.0",
+                "write-file-atomic": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
               },
               "dependencies": {
                 "dot-prop": {
                   "version": "4.2.0",
                   "bundled": true,
                   "requires": {
-                    "is-obj": "1.0.1"
+                    "is-obj": "^1.0.0"
                   },
                   "dependencies": {
                     "is-obj": {
@@ -6321,7 +6322,7 @@
                   "version": "1.2.0",
                   "bundled": true,
                   "requires": {
-                    "pify": "3.0.0"
+                    "pify": "^3.0.0"
                   },
                   "dependencies": {
                     "pify": {
@@ -6334,7 +6335,7 @@
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "crypto-random-string": "1.0.0"
+                    "crypto-random-string": "^1.0.0"
                   },
                   "dependencies": {
                     "crypto-random-string": {
@@ -6353,7 +6354,7 @@
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "ci-info": "1.1.3"
+                "ci-info": "^1.0.0"
               },
               "dependencies": {
                 "ci-info": {
@@ -6366,22 +6367,22 @@
               "version": "0.1.0",
               "bundled": true,
               "requires": {
-                "global-dirs": "0.1.1",
-                "is-path-inside": "1.0.1"
+                "global-dirs": "^0.1.0",
+                "is-path-inside": "^1.0.0"
               },
               "dependencies": {
                 "global-dirs": {
                   "version": "0.1.1",
                   "bundled": true,
                   "requires": {
-                    "ini": "1.3.5"
+                    "ini": "^1.3.4"
                   }
                 },
                 "is-path-inside": {
                   "version": "1.0.1",
                   "bundled": true,
                   "requires": {
-                    "path-is-inside": "1.0.2"
+                    "path-is-inside": "^1.0.1"
                   }
                 }
               }
@@ -6394,41 +6395,41 @@
               "version": "3.1.0",
               "bundled": true,
               "requires": {
-                "package-json": "4.0.1"
+                "package-json": "^4.0.0"
               },
               "dependencies": {
                 "package-json": {
                   "version": "4.0.1",
                   "bundled": true,
                   "requires": {
-                    "got": "6.7.1",
-                    "registry-auth-token": "3.3.2",
-                    "registry-url": "3.1.0",
-                    "semver": "5.5.0"
+                    "got": "^6.7.1",
+                    "registry-auth-token": "^3.0.1",
+                    "registry-url": "^3.0.3",
+                    "semver": "^5.1.0"
                   },
                   "dependencies": {
                     "got": {
                       "version": "6.7.1",
                       "bundled": true,
                       "requires": {
-                        "create-error-class": "3.0.2",
-                        "duplexer3": "0.1.4",
-                        "get-stream": "3.0.0",
-                        "is-redirect": "1.0.0",
-                        "is-retry-allowed": "1.1.0",
-                        "is-stream": "1.1.0",
-                        "lowercase-keys": "1.0.1",
-                        "safe-buffer": "5.1.2",
-                        "timed-out": "4.0.1",
-                        "unzip-response": "2.0.1",
-                        "url-parse-lax": "1.0.0"
+                        "create-error-class": "^3.0.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^3.0.0",
+                        "is-redirect": "^1.0.0",
+                        "is-retry-allowed": "^1.0.0",
+                        "is-stream": "^1.0.0",
+                        "lowercase-keys": "^1.0.0",
+                        "safe-buffer": "^5.0.1",
+                        "timed-out": "^4.0.0",
+                        "unzip-response": "^2.0.1",
+                        "url-parse-lax": "^1.0.0"
                       },
                       "dependencies": {
                         "create-error-class": {
                           "version": "3.0.2",
                           "bundled": true,
                           "requires": {
-                            "capture-stack-trace": "1.0.0"
+                            "capture-stack-trace": "^1.0.0"
                           },
                           "dependencies": {
                             "capture-stack-trace": {
@@ -6473,7 +6474,7 @@
                           "version": "1.0.0",
                           "bundled": true,
                           "requires": {
-                            "prepend-http": "1.0.4"
+                            "prepend-http": "^1.0.1"
                           },
                           "dependencies": {
                             "prepend-http": {
@@ -6488,18 +6489,18 @@
                       "version": "3.3.2",
                       "bundled": true,
                       "requires": {
-                        "rc": "1.2.7",
-                        "safe-buffer": "5.1.2"
+                        "rc": "^1.1.6",
+                        "safe-buffer": "^5.0.1"
                       },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.7",
                           "bundled": true,
                           "requires": {
-                            "deep-extend": "0.5.1",
-                            "ini": "1.3.5",
-                            "minimist": "1.2.0",
-                            "strip-json-comments": "2.0.1"
+                            "deep-extend": "^0.5.1",
+                            "ini": "~1.3.0",
+                            "minimist": "^1.2.0",
+                            "strip-json-comments": "~2.0.1"
                           },
                           "dependencies": {
                             "deep-extend": {
@@ -6522,17 +6523,17 @@
                       "version": "3.1.0",
                       "bundled": true,
                       "requires": {
-                        "rc": "1.2.7"
+                        "rc": "^1.0.1"
                       },
                       "dependencies": {
                         "rc": {
                           "version": "1.2.7",
                           "bundled": true,
                           "requires": {
-                            "deep-extend": "0.5.1",
-                            "ini": "1.3.5",
-                            "minimist": "1.2.0",
-                            "strip-json-comments": "2.0.1"
+                            "deep-extend": "^0.5.1",
+                            "ini": "~1.3.0",
+                            "minimist": "^1.2.0",
+                            "strip-json-comments": "~2.0.1"
                           },
                           "dependencies": {
                             "deep-extend": {
@@ -6559,7 +6560,7 @@
               "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "semver": "5.5.0"
+                "semver": "^5.0.3"
               }
             },
             "xdg-basedir": {
@@ -6576,16 +6577,16 @@
           "version": "3.0.3",
           "bundled": true,
           "requires": {
-            "spdx-correct": "3.0.0",
-            "spdx-expression-parse": "3.0.0"
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
           },
           "dependencies": {
             "spdx-correct": {
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
               },
               "dependencies": {
                 "spdx-license-ids": {
@@ -6598,8 +6599,8 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
               },
               "dependencies": {
                 "spdx-exceptions": {
@@ -6618,7 +6619,7 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "builtins": "1.0.3"
+            "builtins": "^1.0.3"
           },
           "dependencies": {
             "builtins": {
@@ -6631,7 +6632,7 @@
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           },
           "dependencies": {
             "isexe": {
@@ -6644,14 +6645,14 @@
           "version": "1.6.0",
           "bundled": true,
           "requires": {
-            "errno": "0.1.7"
+            "errno": "~0.1.7"
           },
           "dependencies": {
             "errno": {
               "version": "0.1.7",
               "bundled": true,
               "requires": {
-                "prr": "1.0.1"
+                "prr": "~1.0.1"
               },
               "dependencies": {
                 "prr": {
@@ -6670,9 +6671,9 @@
           "version": "2.3.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "signal-exit": "3.0.2"
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
           },
           "dependencies": {
             "signal-exit": {
@@ -6709,9 +6710,9 @@
       "resolved": "https://registry.npmjs.org/object-extended/-/object-extended-0.0.7.tgz",
       "integrity": "sha1-hP0j9WsVWCrrPoiwXLVdJDLWijM=",
       "requires": {
-        "array-extended": "0.0.11",
-        "extended": "0.0.6",
-        "is-extended": "0.0.10"
+        "array-extended": "~0.0.4",
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.3"
       }
     },
     "once": {
@@ -6720,7 +6721,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -6734,8 +6735,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -6751,12 +6752,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -6779,14 +6780,14 @@
       "integrity": "sha512-cDNAN1Ehjbf5EHkNY5qnRhGPUCp6SnpyVof5fRzN800QV1Y2OkzbH9rmjZkbBRa8igof903yOnjIl6z0SlAhxA==",
       "dev": true,
       "requires": {
-        "agent-base": "4.2.0",
-        "debug": "3.1.0",
-        "get-uri": "2.0.2",
-        "http-proxy-agent": "2.1.0",
-        "https-proxy-agent": "2.2.1",
-        "pac-resolver": "3.0.0",
-        "raw-body": "2.3.3",
-        "socks-proxy-agent": "3.0.1"
+        "agent-base": "^4.2.0",
+        "debug": "^3.1.0",
+        "get-uri": "^2.0.0",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1",
+        "pac-resolver": "^3.0.0",
+        "raw-body": "^2.2.0",
+        "socks-proxy-agent": "^3.0.0"
       },
       "dependencies": {
         "debug": {
@@ -6806,11 +6807,11 @@
       "integrity": "sha512-tcc38bsjuE3XZ5+4vP96OfhOugrX+JcnpUbhfuc4LuXBLQhoTthOstZeoQJBDnQUDYzYmdImKsbz0xSl1/9qeA==",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "degenerator": "1.0.4",
-        "ip": "1.1.5",
-        "netmask": "1.0.6",
-        "thunkify": "2.1.2"
+        "co": "^4.6.0",
+        "degenerator": "^1.0.4",
+        "ip": "^1.1.5",
+        "netmask": "^1.0.6",
+        "thunkify": "^2.1.2"
       }
     },
     "packet-reader": {
@@ -6872,9 +6873,9 @@
         "buffer-writer": "1.0.1",
         "packet-reader": "0.3.1",
         "pg-connection-string": "0.1.3",
-        "pg-pool": "2.0.3",
-        "pg-types": "1.12.1",
-        "pgpass": "1.0.2",
+        "pg-pool": "~2.0.3",
+        "pg-types": "~1.12.1",
+        "pgpass": "1.x",
         "semver": "4.3.2"
       }
     },
@@ -6889,24 +6890,24 @@
       "integrity": "sha1-siDxkIl2t7QNqjc8etpfyoI6sNk="
     },
     "pg-minify": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-0.5.4.tgz",
-      "integrity": "sha512-GHB2v4OiMHDgwiHH86ZWNfvgEPVijrnfuWLQocseX6Zlf30k+x0imA65zBy4skIpEwfBBEplIEEKP4n3q9KkVA=="
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-0.5.5.tgz",
+      "integrity": "sha512-7Pf9h6nV1RFqED1hkRosePqvpPwNUUtW06TT4+lHwzesxa5gffxkShTjYH6JXV5sSSfh5+2yHOTTWEkCyCQ0Eg=="
     },
     "pg-pool": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.3.tgz",
-      "integrity": "sha1-wCIDLIlJ8xKk+R+2QJzgQHa+Mlc="
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.10.tgz",
+      "integrity": "sha512-qdwzY92bHf3nwzIUcj+zJ0Qo5lpG/YxchahxIN8+ZVmXqkahKXsnl2aiJPHLYN9o5mB/leG+Xh6XKxtP7e0sjg=="
     },
     "pg-promise": {
       "version": "5.9.7",
       "resolved": "https://registry.npmjs.org/pg-promise/-/pg-promise-5.9.7.tgz",
       "integrity": "sha512-Hp53E6qdjxyuNepIpr7ONbsKZ2GYfi+HbuW4VNMfWcCSZPlE/A9DieYc82AJaz2f9eHcmByeU7TiQTmsBu3hGA==",
       "requires": {
-        "manakin": "0.4.8",
-        "pg": "5.2.1",
-        "pg-minify": "0.4.5",
-        "spex": "1.2.1"
+        "manakin": "^0.4.7",
+        "pg": "^5.1.0",
+        "pg-minify": "0.4",
+        "spex": "1.2"
       },
       "dependencies": {
         "manakin": {
@@ -6928,8 +6929,8 @@
             "js-string-escape": "1.0.1",
             "packet-reader": "0.2.0",
             "pg-connection-string": "0.1.3",
-            "pg-pool": "1.8.0",
-            "pg-types": "1.12.1",
+            "pg-pool": "1.*",
+            "pg-types": "1.*",
             "pgpass": "0.0.6",
             "semver": "4.3.2"
           }
@@ -6953,7 +6954,7 @@
           "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-0.0.6.tgz",
           "integrity": "sha1-9idiANAXOdoe6mMTi9yjX/S9coA=",
           "requires": {
-            "split": "1.0.1"
+            "split": "^1.0.0"
           }
         },
         "spex": {
@@ -6976,10 +6977,10 @@
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
       "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
       "requires": {
-        "postgres-array": "1.0.2",
-        "postgres-bytea": "1.0.0",
-        "postgres-date": "1.0.3",
-        "postgres-interval": "1.1.1"
+        "postgres-array": "~1.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.0",
+        "postgres-interval": "^1.1.0"
       }
     },
     "pgpass": {
@@ -6987,7 +6988,7 @@
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
       "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
       "requires": {
-        "split": "1.0.1"
+        "split": "^1.0.0"
       }
     },
     "picture-tube": {
@@ -6995,13 +6996,13 @@
       "resolved": "https://registry.npmjs.org/picture-tube/-/picture-tube-0.0.4.tgz",
       "integrity": "sha1-Id4Ctxecy3OvCD8RL1JnYy/G6MY=",
       "requires": {
-        "buffers": "0.1.1",
-        "charm": "0.1.2",
-        "event-stream": "0.9.8",
-        "optimist": "0.3.7",
-        "png-js": "0.1.1",
-        "request": "2.9.203",
-        "x256": "0.0.2"
+        "buffers": "~0.1.1",
+        "charm": "~0.1.0",
+        "event-stream": "~0.9.8",
+        "optimist": "~0.3.4",
+        "png-js": "~0.1.0",
+        "request": "~2.9.202",
+        "x256": "~0.0.1"
       },
       "dependencies": {
         "optimist": {
@@ -7009,7 +7010,7 @@
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
           "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
           "requires": {
-            "wordwrap": "0.0.3"
+            "wordwrap": "~0.0.2"
           }
         },
         "request": {
@@ -7037,7 +7038,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-config": {
@@ -7046,9 +7047,9 @@
       "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
       "dev": true,
       "requires": {
-        "debug-log": "1.0.1",
-        "find-root": "1.1.0",
-        "xtend": "4.0.1"
+        "debug-log": "^1.0.0",
+        "find-root": "^1.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "pkginfo": {
@@ -7087,7 +7088,7 @@
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.1.tgz",
       "integrity": "sha512-OkuCi9t/3CZmeQreutGgx/OVNv9MKHGIT5jH8KldQ4NLYXkvmT9nDVxEuCENlNwhlGPE374oA/xMqn05G49pHA==",
       "requires": {
-        "xtend": "4.0.1"
+        "xtend": "^4.0.0"
       }
     },
     "prelude-ls": {
@@ -7112,7 +7113,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "promised-io": {
@@ -7127,14 +7128,14 @@
       "integrity": "sha512-CNKuhC1jVtm8KJYFTS2ZRO71VCBx3QSA92So/e6NrY6GoJonkx3Irnk4047EsCcswczwqAekRj3s8qLRGahSKg==",
       "dev": true,
       "requires": {
-        "agent-base": "4.2.0",
-        "debug": "3.1.0",
-        "http-proxy-agent": "2.1.0",
-        "https-proxy-agent": "2.2.1",
-        "lru-cache": "4.1.3",
-        "pac-proxy-agent": "2.0.2",
-        "proxy-from-env": "1.0.0",
-        "socks-proxy-agent": "3.0.1"
+        "agent-base": "^4.2.0",
+        "debug": "^3.1.0",
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1",
+        "lru-cache": "^4.1.2",
+        "pac-proxy-agent": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "socks-proxy-agent": "^3.0.0"
       },
       "dependencies": {
         "debug": {
@@ -7192,13 +7193,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readline2": {
@@ -7207,8 +7208,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
         "mute-stream": "0.0.5"
       }
     },
@@ -7217,7 +7218,7 @@
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
       "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
       "requires": {
-        "esprima": "3.0.0"
+        "esprima": "~3.0.0"
       }
     },
     "remove-trailing-separator": {
@@ -7231,27 +7232,27 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.86.0.tgz",
       "integrity": "sha512-BQZih67o9r+Ys94tcIW4S7Uu8pthjrQVxhsZ/weOwHbDfACxvIyvnAbzFQxjy1jMtvFSzv5zf4my6cZsJBbVzw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "require-uncached": {
@@ -7260,8 +7261,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -7277,8 +7278,8 @@
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
       "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
       "requires": {
-        "resolve-from": "2.0.0",
-        "semver": "5.5.0"
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
       },
       "dependencies": {
         "semver": {
@@ -7294,7 +7295,7 @@
       "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-from": {
@@ -7308,8 +7309,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "rimraf": {
@@ -7318,7 +7319,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.1"
+        "glob": "^7.0.5"
       }
     },
     "run-async": {
@@ -7327,7 +7328,7 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.0"
       }
     },
     "run-parallel": {
@@ -7393,17 +7394,17 @@
       "integrity": "sha512-/flfGfIxIRXSvZBHJzIf3iAyGYkmMQq6SQjA0cx9SOuVuq+4ZPPO4LJtH1Ce0Lznax1KSG1U6Dad85wIcSW19w==",
       "dev": true,
       "requires": {
-        "build": "0.1.4",
-        "diff": "3.2.0",
+        "build": "^0.1.4",
+        "diff": "^3.1.0",
         "formatio": "1.2.0",
-        "lodash.get": "4.4.2",
-        "lolex": "2.6.0",
-        "native-promise-only": "0.8.1",
-        "nise": "1.3.3",
-        "path-to-regexp": "1.7.0",
-        "samsam": "1.3.0",
+        "lodash.get": "^4.4.2",
+        "lolex": "^2.1.2",
+        "native-promise-only": "^0.8.1",
+        "nise": "^1.0.1",
+        "path-to-regexp": "^1.7.0",
+        "samsam": "^1.1.3",
         "text-encoding": "0.6.4",
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "slice-ansi": {
@@ -7423,7 +7424,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "4.x.x"
       }
     },
     "socks": {
@@ -7432,8 +7433,8 @@
       "integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
       "dev": true,
       "requires": {
-        "ip": "1.1.5",
-        "smart-buffer": "1.1.15"
+        "ip": "^1.1.4",
+        "smart-buffer": "^1.0.13"
       }
     },
     "socks-proxy-agent": {
@@ -7442,8 +7443,8 @@
       "integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
       "dev": true,
       "requires": {
-        "agent-base": "4.2.0",
-        "socks": "1.1.10"
+        "agent-base": "^4.1.0",
+        "socks": "^1.1.10"
       }
     },
     "source-map": {
@@ -7459,7 +7460,7 @@
       "integrity": "sha1-w73kYlKxNU5xDEsgDVSBa9nwejI=",
       "requires": {
         "here": "0.0.2",
-        "nopt": "2.1.2"
+        "nopt": "~2.1.2"
       }
     },
     "spex": {
@@ -7472,7 +7473,7 @@
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "sprintf-js": {
@@ -7486,14 +7487,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stack-trace": {
@@ -7507,14 +7508,14 @@
       "integrity": "sha1-sOZl4yJ32jy5nyEmmxBC2B7+sGs=",
       "dev": true,
       "requires": {
-        "eslint": "2.2.0",
+        "eslint": "~2.2.0",
         "eslint-config-standard": "5.1.0",
         "eslint-config-standard-jsx": "1.1.1",
-        "eslint-plugin-promise": "1.3.2",
-        "eslint-plugin-react": "4.3.0",
-        "eslint-plugin-standard": "1.3.3",
-        "standard-engine": "3.3.1",
-        "xtend": "4.0.1"
+        "eslint-plugin-promise": "^1.0.8",
+        "eslint-plugin-react": "^4.0.0",
+        "eslint-plugin-standard": "^1.3.1",
+        "standard-engine": "^3.3.0",
+        "xtend": "^4.0.1"
       }
     },
     "standard-engine": {
@@ -7523,14 +7524,14 @@
       "integrity": "sha1-sveY3k5NPh+s7UJcgTaDGmZ0CO0=",
       "dev": true,
       "requires": {
-        "defaults": "1.0.3",
-        "deglob": "1.1.2",
-        "find-root": "1.1.0",
-        "get-stdin": "5.0.1",
-        "minimist": "1.2.0",
-        "multiline": "1.0.2",
-        "pkg-config": "1.1.1",
-        "xtend": "4.0.1"
+        "defaults": "^1.0.2",
+        "deglob": "^1.0.0",
+        "find-root": "^1.0.0",
+        "get-stdin": "^5.0.1",
+        "minimist": "^1.1.0",
+        "multiline": "^1.0.2",
+        "pkg-config": "^1.0.1",
+        "xtend": "^4.0.0"
       }
     },
     "statuses": {
@@ -7544,10 +7545,10 @@
       "resolved": "https://registry.npmjs.org/string-extended/-/string-extended-0.0.8.tgz",
       "integrity": "sha1-dBlX3/SHsCcqee7FpE8jnubxfM0=",
       "requires": {
-        "array-extended": "0.0.11",
-        "date-extended": "0.0.6",
-        "extended": "0.0.6",
-        "is-extended": "0.0.10"
+        "array-extended": "~0.0.5",
+        "date-extended": "~0.0.3",
+        "extended": "~0.0.3",
+        "is-extended": "~0.0.3"
       }
     },
     "string-width": {
@@ -7556,9 +7557,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -7566,7 +7567,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -7574,7 +7575,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-indent": {
@@ -7583,7 +7584,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       },
       "dependencies": {
         "get-stdin": {
@@ -7610,11 +7611,11 @@
       "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-4.1.0.tgz",
       "integrity": "sha512-iFbOBWYaznBNbheIKaMkj+3EabpEsXbuwcTVuYkRjoav+Om5L8VXXLIXms0cHxkouXMRCQaSfhfau9/HyIbM2Q==",
       "requires": {
-        "command-exists": "1.2.6",
-        "concat-stream": "1.6.2",
-        "get-port": "3.2.0",
-        "http-response-object": "1.1.0",
-        "then-request": "2.2.0"
+        "command-exists": "^1.2.2",
+        "concat-stream": "^1.6.0",
+        "get-port": "^3.1.0",
+        "http-response-object": "^1.1.0",
+        "then-request": "^2.2.0"
       }
     },
     "table": {
@@ -7623,12 +7624,12 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
-        "lodash": "4.17.10",
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.0.0",
+        "chalk": "^1.1.1",
+        "lodash": "^4.0.0",
         "slice-ansi": "0.0.4",
-        "string-width": "2.1.1"
+        "string-width": "^2.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -7637,8 +7638,8 @@
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "ansi-regex": {
@@ -7659,8 +7660,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -7669,7 +7670,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -7680,13 +7681,13 @@
       "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
       "dev": true,
       "requires": {
-        "bl": "1.2.2",
-        "buffer-alloc": "1.1.0",
-        "end-of-stream": "1.4.1",
-        "fs-constants": "1.0.0",
-        "readable-stream": "2.3.6",
-        "to-buffer": "1.1.1",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.1.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.0",
+        "xtend": "^4.0.0"
       }
     },
     "term-canvas": {
@@ -7711,12 +7712,12 @@
       "resolved": "https://registry.npmjs.org/then-request/-/then-request-2.2.0.tgz",
       "integrity": "sha1-ZnizL6DKIY/laZgbvYhxtZQGDYE=",
       "requires": {
-        "caseless": "0.11.0",
-        "concat-stream": "1.6.2",
-        "http-basic": "2.5.1",
-        "http-response-object": "1.1.0",
-        "promise": "7.3.1",
-        "qs": "6.5.2"
+        "caseless": "~0.11.0",
+        "concat-stream": "^1.4.7",
+        "http-basic": "^2.5.1",
+        "http-response-object": "^1.1.0",
+        "promise": "^7.1.1",
+        "qs": "^6.1.0"
       },
       "dependencies": {
         "caseless": {
@@ -7760,7 +7761,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "tunnel-agent": {
@@ -7768,7 +7769,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -7783,7 +7784,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -7843,7 +7844,7 @@
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "util-deprecate": {
@@ -7861,9 +7862,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "walker": {
@@ -7872,7 +7873,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
-        "makeerror": "1.0.11"
+        "makeerror": "1.0.x"
       }
     },
     "winston": {
@@ -7880,12 +7881,12 @@
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.2.tgz",
       "integrity": "sha512-4S/Ad4ZfSNl8OccCLxnJmNISWcm2joa6Q0YGDxlxMzH0fgSwWsjMt+SmlNwCqdpaPg3ev1HKkMBsIiXeSUwpbA==",
       "requires": {
-        "async": "1.0.0",
-        "colors": "1.0.3",
-        "cycle": "1.0.3",
-        "eyes": "0.1.8",
-        "isstream": "0.1.2",
-        "stack-trace": "0.0.10"
+        "async": "~1.0.0",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "stack-trace": "0.0.x"
       }
     },
     "wordwrap": {
@@ -7911,7 +7912,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "x256": {
@@ -7924,8 +7925,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
       "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
       "requires": {
-        "sax": "1.2.1",
-        "xmlbuilder": "4.2.1"
+        "sax": ">=0.6.0",
+        "xmlbuilder": "^4.1.0"
       }
     },
     "xmlbuilder": {
@@ -7933,7 +7934,7 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
       "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.0.0"
       }
     },
     "xmldom": {
@@ -7964,10 +7965,10 @@
       "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
       "dev": true,
       "requires": {
-        "archiver-utils": "1.3.0",
-        "compress-commons": "1.2.2",
-        "lodash": "4.17.10",
-        "readable-stream": "2.3.6"
+        "archiver-utils": "^1.3.0",
+        "compress-commons": "^1.2.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "author": "NYPL Discovery",
   "dependencies": {
-    "@nypl/nypl-core-objects": "^1.2.0",
+    "@nypl/nypl-core-objects": "^1.3.1",
     "@nypl/nypl-streams-client": "^0.1.2",
     "JSONStream": "^1.2.1",
     "avsc": "^5.0.0",
     "aws-sdk": "^2.53.0",
     "blessed": "^0.1.81",
     "blessed-contrib": "^3.5.5",
-    "discovery-store-models": "https://github.com/NYPL-discovery/discovery-store-models.git#v1.2.1",
+    "discovery-store-models": "git+https://github.com/NYPL-discovery/discovery-store-models.git#v1.3.0",
     "dotenv": "^4.0.0",
     "elasticsearch": "^13.0.1",
     "fast-csv": "^2.3.0",

--- a/test/bib-serializations-test.js
+++ b/test/bib-serializations-test.js
@@ -5,7 +5,7 @@ const sinon = require('sinon')
 const path = require('path')
 const fs = require('fs')
 
-const ResourceSerializer = require('../lib/es-serializer').ResourceSerializer
+const ResourceSerializer = require('../lib/serializers/resource-serializer')
 const DiscoveryStoreModels = require('discovery-store-models')
 const { Bib } = DiscoveryStoreModels
 
@@ -512,6 +512,53 @@ describe('Bib Serializations', function () {
           assert(itemsWithHighItype.length > 0)
         })
       })
+    })
+  })
+
+  describe('holdings', () => {
+    let testBib
+    before((done) => {
+      Bib.byId('b11254422').then((bib) => {
+        ResourceSerializer.serialize(bib).then((serialBib) => {
+          testBib = serialBib
+          done()
+        })
+      })
+    })
+
+    it('should have a shelfMark', () => {
+      assert.equal(testBib.holdings[0].shelfMark, 'MFWA+ 89-1277')
+    })
+
+    it('should include multiple HoldingStatements', () => {
+      assert.equal(testBib.holdings[0].holdingStatement[0], '27(1988)-40:156(2020)-')
+      assert.equal(testBib.holdings[0].holdingStatement[1], 'no. 3840 (2018/2020)')
+    })
+
+    it('should include location fields', () => {
+      assert.equal(testBib.holdings[0].location[0].code, 'loc:rc2ma')
+      assert.equal(testBib.holdings[0].location[0].label, 'Offsite')
+    })
+
+    it('should have a format', () => {
+      assert.equal(testBib.holdings[0].format[0], '{"PRINT"}')
+    })
+
+    it('should contain an array of ordered checkInBoxes', () => {
+      const firstBox = testBib.holdings[0].checkInBoxes[0]
+      const lastBox = testBib.holdings[0].checkInBoxes[testBib.holdings[0].checkInBoxes.length - 1]
+
+      assert.equal(firstBox.coverage, '37:143 (2017--)')
+      assert.equal(firstBox.status, 'Arrived')
+      assert.equal(firstBox.copies, null)
+      assert.equal(firstBox.position, '1')
+      assert.equal(firstBox.shelfMark, 'MFWA+ 89-1277')
+
+      assert.equal(lastBox.coverage, '40:157 (2020--)')
+      assert.equal(lastBox.status, 'Expected')
+      assert.equal(lastBox.copies, null)
+      assert.equal(lastBox.position, '15')
+      assert.equal(lastBox.shelfMark, 'MFWA+ 89-1277')
     })
   })
 

--- a/test/data/b11254422.json
+++ b/test/data/b11254422.json
@@ -1,0 +1,1042 @@
+{
+    "subject_id": "b11254422",
+    "bib_statements": [
+      {
+        "bn": null,
+        "id": "carriertypes:nc",
+        "la": "volume",
+        "li": null,
+        "pr": "bf:carrier",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "30 cm.",
+        "pr": "bf:dimensions",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": "urn:biblevel:s",
+        "la": "serial",
+        "li": null,
+        "pr": "bf:issuance",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": "mediatypes:n",
+        "la": "unmediated",
+        "li": null,
+        "pr": "bf:media",
+        "ty": null
+      },
+      {
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": "Note",
+            "pr": "bf:noteType",
+            "ty": null
+          },
+          {
+            "id": "bf:Note",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Cover title.",
+            "pr": "rdfs:label",
+            "ty": null
+          }
+        ],
+        "id": "b11254422#1.0000",
+        "la": null,
+        "li": null,
+        "pr": "bf:note",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "9999",
+        "pr": "dbo:endDate",
+        "ty": "xsd:integer"
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "1981",
+        "pr": "dbo:startDate",
+        "ty": "xsd:integer"
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "1981",
+        "pr": "dc:date",
+        "ty": "xsd:integer"
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "Photography -- History -- Periodicals.",
+        "pr": "dc:subject",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "Photography, Artistic -- Periodicals.",
+        "pr": "dc:subject",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "Fotogeschichte",
+        "pr": "dcterms:alternative",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "Fotogeschichte",
+        "pr": "dcterms:alternative",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "1981",
+        "pr": "dcterms:created",
+        "ty": "xsd:integer"
+      },
+      {
+        "bn": null,
+        "id": "11254422",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:identifier",
+        "ty": "nypl:Bnumber"
+      },
+      {
+        "bn": null,
+        "id": "0720-5260",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:identifier",
+        "ty": "bf:Issn"
+      },
+      {
+        "bn": null,
+        "id": "82645711",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:identifier",
+        "ty": "bf:Lccn"
+      },
+      {
+        "bn": null,
+        "id": "(WaOLN)nyp1262092",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:identifier",
+        "ty": "bf:Identifier"
+      },
+      {
+        "bn": null,
+        "id": "lang:ger",
+        "la": "German",
+        "li": null,
+        "pr": "dcterms:language",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "Fotogeschichte.",
+        "pr": "dcterms:title",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": "resourcetypes:txt",
+        "la": "Text",
+        "li": null,
+        "pr": "dcterms:type",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": "loc:mal",
+        "la": "Schwarzman Building - Main Reading Room 315",
+        "li": null,
+        "pr": "nypl:catalogBibLocation",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": "loc:mas",
+        "la": "Schwarzman Building - Photography Collection Room 308",
+        "li": null,
+        "pr": "nypl:catalogBibLocation",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "v. : ill. ;",
+        "pr": "nypl:extent",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "TR15 .F67",
+        "pr": "nypl:lccClassification",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "Frankfurt am Main :",
+        "pr": "nypl:placeOfPublication",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "Frankfurt am Main : T. Starl, 1981-",
+        "pr": "nypl:publicationStatement",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "T. Starl,",
+        "pr": "nypl:role-publisher",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "Jahrg. 1, Heft 1-",
+        "pr": "nypl:serialPublicationDates",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "MFWA+ 89-1277",
+        "pr": "nypl:shelfMark",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "false",
+        "pr": "nypl:suppressed",
+        "ty": "xsd:boolean"
+      },
+      {
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "Fotogeschichte.",
+        "pr": "nypl:titleDisplay",
+        "ty": null
+      },
+      {
+        "bn": null,
+        "id": "nypl:Collection",
+        "la": null,
+        "li": null,
+        "pr": "rdfs:type",
+        "ty": null
+      }
+    ],
+    "item_statements": [],
+    "holding_statements": [
+      {
+        "s": "h1000993",
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "MFWA+ 89-1277",
+        "pr": "bf:physicalLocation",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "27(1988)-40:156(2020)-",
+        "pr": "dcterms:coverage",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "no. 3840 (2018/2020)",
+        "pr": "dcterms:coverage",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "{\"PRINT\"}",
+        "pr": "dcterms:format",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "15",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Expected",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "40:157 (2020--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0000",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "14",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "40:156 (2020--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0001",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "9",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "39:151 (2019--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0002",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "13",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "40:155 (2020--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0003",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "12",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "39:154 (2019--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0004",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "11",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "39:153 (2019--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0005",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "10",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "39:152 (2019--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0006",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "7",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "38:149 (2018--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0007",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "6",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "38:148 (2018--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0008",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "5",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "38:147 (2018--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0009",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "4",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "37:146 (2017--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0010",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "3",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "37:145 (2017--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0011",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "2",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "37:144 (2017--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0012",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "1",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "37:143 (2017--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0013",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": [
+          {
+            "id": null,
+            "la": null,
+            "li": null,
+            "pr": "bf:count",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "8",
+            "pr": "bf:part",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "Arrived",
+            "pr": "bf:status",
+            "ty": null
+          },
+          {
+            "id": null,
+            "la": null,
+            "li": "38:150 (2018--)",
+            "pr": "dcterms:coverage",
+            "ty": null
+          },
+          {
+            "id": "nypl:CheckInBox",
+            "la": null,
+            "li": null,
+            "pr": "rdf:type",
+            "ty": null
+          }
+        ],
+        "id": "h1000993#1.0014",
+        "la": null,
+        "li": null,
+        "pr": "dcterms:hasPart",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": null,
+        "id": "urn:bnum:b11254422",
+        "la": null,
+        "li": null,
+        "pr": "nypl:bnum",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": null,
+        "id": "loc:rc2ma",
+        "la": "Offsite",
+        "li": null,
+        "pr": "nypl:holdingLocation",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "MFWA+ 89-1277",
+        "pr": "nypl:shelfMark",
+        "ty": null
+      },
+      {
+        "s": "h1000993",
+        "bn": null,
+        "id": null,
+        "la": null,
+        "li": "false",
+        "pr": "nypl:suppressed",
+        "ty": "xsd:boolean"
+      },
+      {
+        "s": "h1000993",
+        "bn": null,
+        "id": "nypl:Holding",
+        "la": null,
+        "li": null,
+        "pr": "rdfs:type",
+        "ty": null
+      }
+    ]
+  }


### PR DESCRIPTION
This extends the api-indexer to include `Holding` records in the ElasticSearch index for the SCC API. These records are treated in largely the same way that `Item` records are handled, so it is mostly an extension along those principles. This has been tested (in a limited way) locally and verified at least to write the proper objects to the ES index, though more thorough testing will need to be conducted in the QA environment to ensure that this handles everything properly.

The major changes are:

- A refactor of the `serializer` code. With the addition of an additional class it felt like having all of these in a single file was getting unweildy, so I split them out into their own files in a sub-directory. I think this makes these components easier to maintain/understand
- Added the `resource-holding-serializer` as part of the above work, which is a simple serializer and does not introduce any new ideas into this module
- Extended the `resource-item-serializer` to provide additional fields for separated `shelfMark` data
- Extend the ElasticSearch mapping in `index.js` to add all necessary fields
- Bumped some package versions for NYPL packages to pull in `Holding` updates from upstream, mostly dealing with retrieving these records from discovery-store
- Added some simple tests to validate the serializations