### PR TITLE
SCC-2271 Add missing statements to ES index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 node_js:
 - '10.16'
+cache: npm
 script: npm test
-cache:
-  directories:
-   - node_modules
 before_deploy:
  - echo "All unit tests passed; Preparing to deploy $TRAVIS_BRANCH"
 deploy:

--- a/lib/serializers/resource-item-serializer.js
+++ b/lib/serializers/resource-item-serializer.js
@@ -42,7 +42,9 @@ class ResourceItemSerializer extends EsSerializer {
     // Add call number components
     ; [ 'Physical Location', 'Enumeration Chronology' ].forEach((name) => {
       itemFieldMapper.getMapping(name, (spec) => {
-        this.addStatement(spec.jsonLdKey, spec.object_literal)
+        this.object.each(spec.pred, (triple) => {
+          this.addStatement(spec.jsonLdKey, triple.object_literal)
+        })
       })
     })
 

--- a/test/bib-serializations-test.js
+++ b/test/bib-serializations-test.js
@@ -514,6 +514,15 @@ describe('Bib Serializations', function () {
         })
       })
     })
+
+    it('should set physicalLocation and enumerationChronology fields', () => {
+      return Bib.byId('b19834195').then((bib) => {
+        return ResourceSerializer.serialize(bib).then((serialized) => {
+          assert.strictEqual(serialized.items[29].physicalLocation[0], '*T-Mss 1991-010')
+          assert.strictEqual(serialized.items[29].enumerationChronology[0], 'Box 30')
+        })
+      })
+    })
   })
 
   describe('holdings', () => {

--- a/test/data/b19834195.json
+++ b/test/data/b19834195.json
@@ -494,6 +494,22 @@
       "bn": null,
       "id": null,
       "la": null,
+      "li": "*T-Mss 1991-010",
+      "pr": "bf:physicalLocation"
+    },
+    {
+      "s": "i30467062",
+      "bn": null,
+      "id": null,
+      "la": null,
+      "li": "Box 30",
+      "pr": "bf:enumerationAndChronology"
+    },
+    {
+      "s": "i30467062",
+      "bn": null,
+      "id": null,
+      "la": null,
       "li": "false",
       "pr": "nypl:suppressed"
     },


### PR DESCRIPTION
A minor typo in the `Item` serializer was omitting the new `physicalLocation` and `enumerationChronology` fields due to a missing call to the object. This adds that call and extends one of the test bib records to include these fields, which supports a new unit test.

This also includes a minor update to the travis caching, which was using an old style of reference that seemed to be causing issues for some reason.